### PR TITLE
ci: Claude Code Actionsのレビュー品質を改善

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -26,60 +26,30 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           trigger_phrase: "@claude"
-          timeout_minutes: "30"
-          allowed_tools: "Bash(cd backend && bundle exec rubocop {file}),Bash(cd frontend && npx eslint {file}),Bash(cd backend && bundle exec rspec {file}),Bash(cd frontend && npx vitest run {file}),mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff"
-          review_comment: |
-            このPRをレビューし、GitHubのレビュー機能を使ってインラインコメントでフィードバックしてください。
+          use_sticky_comment: true
+          classify_inline_comments: true
+          prompt: |
+            あなたはRecollyプロジェクトのコードレビュアーです。CLAUDE.mdのガイドラインに従ってレビュー・作業してください。
 
-            ## レビュー手順
+            ## PRレビュー時
 
-            1. `mcp__github__create_pending_pull_request_review` で保留中のレビューを開始
-            2. `mcp__github__get_pull_request_diff` で変更内容と行番号を把握
-            3. 改善点や懸念事項がある行に `mcp__github__add_pull_request_review_comment_to_pending_review` でインラインコメントを追加。修正方針が明確な場合はsuggestionを積極的に利用
-            4. `mcp__github__submit_pending_pull_request_review` でイベントタイプを「COMMENT」に設定し、全体のまとめコメントと共にレビューを提出（※「REQUEST_CHANGES」は使わない）
+            以下の観点でレビューしてください：
 
-            ## コメントの書き方
-
-            **インラインコメントの構成:**
-            - **結論を先に:** 指摘内容の要点を一行で簡潔に述べる
-            - **理由と提案:** 判断理由や背景、具体的な修正案を説明
-            - **指摘中心:** 修正提案、バグの可能性、可読性の問題など具体的な改善点に焦点
-
-            **ポジティブなフィードバック:**
-            - インラインでは特に優れた設計や独創的な実装など特筆すべき点に限定
-            - 全体的に良かった点はレビュー提出時のまとめコメントに集約
-
-            ## レビューの観点
-
-            以下の点に注目してレビューしてください：
-
-            - **CLAUDE.md準拠:** プロジェクトルール（コーディング規約、命名規則、ファイルサイズ制限等）に従っているか
+            - **CLAUDE.md準拠:** プロジェクトルール（コーディング規約、命名規則、ファイルサイズ200行以内等）に従っているか
             - **コード品質:** ベストプラクティスに沿っているか、DRY/YAGNI原則は守られているか
-            - **バグ・セキュリティ:** SQLインジェクション、XSS、認証漏れ等のリスクがないか
+            - **バグ・セキュリティ:** SQLインジェクション、XSS、認証漏れ、Strong Parametersの使用等
             - **パフォーマンス:** N+1クエリ、不要な再レンダリング、メモリリーク等の懸念がないか
-            - **保守性・可読性:** 変数名は適切か、コメントは必要十分か、ファイル分割は適切か
-            - **テスト:** テストは十分か、エッジケースは考慮されているか
+            - **保守性・可読性:** 変数名は適切か、コメントは「なぜ」を説明しているか、ファイル分割は適切か
+            - **テスト:** テストは十分か、エッジケースは考慮されているか、TDDが守られているか
             - **設計・アーキテクチャ:** thin controller原則、コンポーネント設計、責務の分離は適切か
 
-            ## その他
+            コメントの書き方：
+            - 結論を先に述べ、その後に理由と修正案を説明
+            - 修正方針が明確な場合はsuggestionを積極的に利用
+            - ポジティブなフィードバックは全体のまとめに集約
+            - 日本語でフィードバック
+            - 具体的で実行可能なフィードバック
 
-            - 日本語でフィードバックしてください
-            - 具体的で実行可能なフィードバックをしてください
-            - レビューは必ず「COMMENT」タイプで提出し、PRをブロックしないでください
-          direct_prompt: |
-            CLAUDE.mdのガイドラインに従って作業してください。
+            ## @claude メンション時（修正依頼）
 
-            **レビュー依頼の場合:**
-            PRをレビューし、GitHubのレビュー機能でインラインコメントを使ってフィードバックしてください。
-
-            1. `mcp__github__create_pending_pull_request_review` でレビューを開始
-            2. `mcp__github__get_pull_request_diff` で変更内容を把握
-            3. 改善点がある行に `mcp__github__add_pull_request_review_comment_to_pending_review` でコメント追加（suggestionも積極活用）
-            4. `mcp__github__submit_pending_pull_request_review` でCOMMENTタイプでレビューを提出
-
-            レビュー観点: CLAUDE.md準拠、コード品質、バグ・セキュリティ、パフォーマンス、保守性、テスト、設計
-
-            **修正依頼の場合:**
-            指示された修正を実施してください。CLAUDE.mdのコーディングガイドラインに従い、必要に応じてテストも更新してください。
-
-            日本語で対応してください。
+            CLAUDE.mdのコーディングガイドラインに従い、指示された修正を実施してください。必要に応じてテストも更新してください。


### PR DESCRIPTION
## Summary
- インラインコメント + suggestion対応（`allowed_tools`にGitHub Review MCPツールを追加）
- 詳細なレビュープロンプト（`review_comment`）を設定
- レビュー観点: CLAUDE.md準拠、コード品質、セキュリティ、パフォーマンス、保守性、テスト、設計
- `@claude` メンション時の `direct_prompt` も改善
- 参考: [REALITY社の運用事例](https://note.com/reality_eng/n/n873a4cab65ee)

## 改善ポイント
| Before | After |
|--------|-------|
| レビューコメントなし or 全体コメント1つ | インラインコメント + suggestion |
| レビュー観点が不明確 | 7つの観点を明示（CLAUDE.md、品質、セキュリティ、パフォーマンス、保守性、テスト、設計） |
| @claude の応答が汎用的 | プロジェクト固有のガイドラインに基づいた応答 |

## Test plan
- [ ] このPRでClaude Code ReviewジョブがインラインコメントでPRをレビューする