### PR TITLE
fix: Claude Code ReviewのMCPツール権限を修正

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -27,6 +27,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
+          claude_args: '--allowedTools mcp__github__create_pending_pull_request_review mcp__github__add_pull_request_review_comment_to_pending_review mcp__github__submit_pending_pull_request_review mcp__github__get_pull_request_diff'
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
 


### PR DESCRIPTION
## Summary
- code-reviewプラグインが使用するGitHub Review MCPツールを`claude_args`で明示的に許可
- 許可ツール: create_pending_review, add_review_comment, submit_review, get_diff

## 背景
前回のPR #7で`permission_denials_count: 1`が発生し、レビューコメントが投稿されなかった。
code-reviewプラグインがMCPツールを使おうとしたが、デフォルトのallowed toolsに含まれていなかったため。

## Test plan
- [ ] マージ後、次のPRでClaude Code Reviewがインラインコメントを投稿する