### PR TITLE
fix: Claude Code Reviewを公式推奨設定に修正 (closes #10)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, ready_for_review, reopened]
+    types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
   pull_request_review_comment:
@@ -16,7 +16,6 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-      issues: write
       id-token: write
     steps:
       - uses: actions/checkout@v4
@@ -25,11 +24,32 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          claude_args: '--allowedTools mcp__github__create_pending_pull_request_review mcp__github__add_pull_request_review_comment_to_pending_review mcp__github__submit_pending_pull_request_review mcp__github__get_pull_request_diff'
           prompt: |
-            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            このPRをレビューしてください。CLAUDE.mdのプロジェクトルールに従ってレビューしてください。
+
+            ## レビュー観点
+            - **CLAUDE.md準拠:** コーディング規約、命名規則、ファイルサイズ（200行以内）等
+            - **コード品質:** DRY / YAGNI原則、ベストプラクティス
+            - **バグ・セキュリティ:** SQLインジェクション、XSS、認証漏れ、Strong Parameters
+            - **パフォーマンス:** N+1クエリ、不要な再レンダリング、メモリリーク
+            - **保守性・可読性:** 変数名、コメント（「なぜ」の説明）、ファイル分割
+            - **テスト:** カバレッジ、エッジケース、TDD遵守
+            - **設計・アーキテクチャ:** thin controller、コンポーネント設計、責務の分離
+
+            ## コメントの書き方
+            - 結論を先に述べ、その後に理由と修正案を説明
+            - 具体的で実行可能なフィードバック
+            - 日本語でフィードバック
+
+            ## コメント投稿方法
+            - `gh pr comment` で全体フィードバックを投稿
+            - `mcp__github_inline_comment__create_inline_comment`（`confirmed: true`）で具体的なコード箇所にインラインコメント
+            - GitHub コメントのみ投稿し、メッセージとしてテキストを出力しない
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
 
   # @claude メンション対応（コメントで呼び出された時）
   claude-assist:


### PR DESCRIPTION
## 変更内容の説明（自分の言葉で）

### このPRは何をするのか
Claude Code Reviewがレビューコメントを投稿できない問題（Issue #10）を修正する。

### なぜこの実装方法にしたのか
公式ドキュメント（solutions.md）の「Automatic PR Code Review」パターンに従った。
以前の設定は `code-review` プラグイン + 誤ったMCPツール名を使用しており、コメント投稿が全て権限拒否されていた。

修正内容:
- `code-review` プラグイン → `prompt` ベースのレビュー指示
- `mcp__github__create_pending_pull_request_review` → `mcp__github_inline_comment__create_inline_comment`
- `Bash(gh pr comment:*)` でトップレベルコメントを投稿

### 影響範囲（この変更で壊れる可能性があるところ）
ワークフロー変更のため、このPR自体ではOIDC検証が失敗する（想定内）。マージ後の次のPRから正常動作する。

## 理解度チェック（理解負債対策）

- [x] このPRで変更したコードの動作を、自分の言葉で説明できる
- [x] 新しく導入したライブラリ・パターンの役割を理解している
- [x] このコードが壊れやすいポイントを把握している
- [x] 設計判断があった場合、ADRを作成または更新した
- [x] 新技術を使った場合、学習ノートの作成を検討した

## AI利用の記録

- [x] このPRにAI生成コードを含む
  - 含む場合、特に注意が必要な箇所: ワークフロー設定（公式ドキュメント準拠で作成）