### PR TITLE
fix: バックエンドデプロイをSSM Run Commandに変更

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,14 +72,31 @@ jobs:
           docker build -f backend/Dockerfile.production -t $ECR_REGISTRY/recolly-backend:$IMAGE_TAG backend/
           docker push $ECR_REGISTRY/recolly-backend:$IMAGE_TAG
 
-      - name: Deploy to EC2
-        env:
-          ECR_REGISTRY: ${{ steps.ecr-login.outputs.registry }}
-          IMAGE_TAG: ${{ github.sha }}
-        uses: appleboy/ssh-action@v1
-        with:
-          host: ${{ secrets.EC2_HOST }}
-          username: ec2-user
-          key: ${{ secrets.EC2_SSH_KEY }}
-          script: |
-            bash /home/ec2-user/deploy.sh ${{ env.ECR_REGISTRY }} ${{ env.IMAGE_TAG }}
+      - name: Deploy to EC2 via SSM
+        run: |
+          COMMAND_ID=$(aws ssm send-command \
+            --instance-ids ${{ secrets.EC2_INSTANCE_ID }} \
+            --document-name "AWS-RunShellScript" \
+            --parameters "commands=[\"bash /home/ec2-user/deploy.sh ${{ steps.ecr-login.outputs.registry }} ${{ github.sha }}\"]" \
+            --query "Command.CommandId" \
+            --output text)
+          echo "SSM Command ID: $COMMAND_ID"
+          aws ssm wait command-executed \
+            --command-id "$COMMAND_ID" \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} || true
+          STATUS=$(aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --query "Status" --output text)
+          echo "Status: $STATUS"
+          aws ssm get-command-invocation \
+            --command-id "$COMMAND_ID" \
+            --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+            --query "StandardOutputContent" --output text
+          if [ "$STATUS" != "Success" ]; then
+            aws ssm get-command-invocation \
+              --command-id "$COMMAND_ID" \
+              --instance-id ${{ secrets.EC2_INSTANCE_ID }} \
+              --query "StandardErrorContent" --output text
+            exit 1
+          fi

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -42,6 +42,12 @@ resource "aws_iam_role_policy_attachment" "ec2_ecr" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
 }
 
+# EC2がSSMエージェントとして動作する権限
+resource "aws_iam_role_policy_attachment" "ec2_ssm_managed" {
+  role       = aws_iam_role.ec2.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
 # EC2インスタンスプロファイル
 resource "aws_iam_instance_profile" "ec2" {
   name = "${var.project_name}-ec2-instance-profile"
@@ -112,6 +118,12 @@ data "aws_iam_policy_document" "github_actions" {
   # CloudFrontキャッシュクリア権限
   statement {
     actions   = ["cloudfront:CreateInvalidation"]
+    resources = ["*"]
+  }
+
+  # SSM Run Command権限（EC2へのデプロイ用）
+  statement {
+    actions   = ["ssm:SendCommand", "ssm:GetCommandInvocation"]
     resources = ["*"]
   }
 }


### PR DESCRIPTION
## Summary

- SSH経由のデプロイ → SSM Run Commandに変更
- EC2のセキュリティグループでSSHがAdmin IPのみに制限されているため、GitHub Actionsから接続不可だった
- SSMならSSHポート不要、IAMロール経由で安全にコマンド実行可能

## Changes

- `.github/workflows/cd.yml`: `appleboy/ssh-action` → `aws ssm send-command`
- `infra/iam.tf`: EC2に`AmazonSSMManagedInstanceCore`、GitHub Actionsに`ssm:SendCommand`権限を追加

## Test plan

- [ ] マージ後にCDワークフロー（フロント+バックエンド）が両方成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)