### PR TITLE
fix: Dockerfileのbin/実行権限を修正

### DIFF
--- a/backend/Dockerfile.production
+++ b/backend/Dockerfile.production
@@ -14,6 +14,7 @@ RUN bundle config set --local without 'development test' && \
     bundle install --jobs 4
 
 COPY . .
+RUN chmod +x bin/*
 
 # === ランタイムステージ ===
 FROM ruby:3.3-slim


### PR DESCRIPTION
## Summary

- 非rootユーザー(rails)で`bin/rails`が`permission denied`になる問題を修正
- ビルドステージで`chmod +x bin/*`を追加

## Test plan

- [ ] マージ後にCDワークフローが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)