### PR TITLE
fix: 本番OAuthコールバックURLのredirect_uri_mismatchを修正

### DIFF
--- a/backend/config/initializers/devise.rb
+++ b/backend/config/initializers/devise.rb
@@ -52,8 +52,14 @@ Devise.setup do |config|
   config.omniauth_path_prefix = '/api/v1/auth'
 
   # OmniAuthプロバイダ設定（ADR-0013）
+  # 本番ではCloudFront経由のため、コールバックURLを明示的に指定する必要がある
+  # （EC2が自身のホスト名でURLを生成すると、Googleの登録URLと一致しない）
+  google_callback_url = if ENV['FRONTEND_URL'].present?
+                          "#{ENV['FRONTEND_URL']}/api/v1/auth/google_oauth2/callback"
+                        end
   config.omniauth :google_oauth2,
                   ENV['GOOGLE_CLIENT_ID'],
                   ENV['GOOGLE_CLIENT_SECRET'],
-                  scope: 'email,profile'
+                  scope: 'email,profile',
+                  callback_url: google_callback_url
 end


### PR DESCRIPTION
## Summary
- OmniAuthがEC2のホスト名でコールバックURLを自動生成し、Googleの `redirect_uri_mismatch` エラーが発生する問題を修正
- `FRONTEND_URL` 環境変数が設定されている場合、コールバックURLを明示的に構築する

## 原因
CloudFront → EC2 経路で、EC2側がリクエストのHostヘッダからコールバックURLを生成すると、
`http://EC2のIP/api/v1/auth/google_oauth2/callback` のようになり、
Google Cloud Consoleに登録された `https://d1libv2nochxfe.cloudfront.net/...` と一致しない。

## Test Plan
- [ ] マージ後、本番でGoogleログインが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)