### PR TITLE
fix: ダッシュボード・ライブラリのUI微調整

### DIFF
--- a/frontend/src/components/DashboardEmptyState/DashboardEmptyState.module.css
+++ b/frontend/src/components/DashboardEmptyState/DashboardEmptyState.module.css
@@ -67,6 +67,7 @@
   flex-direction: column;
   align-items: center;
   gap: var(--spacing-sm);
+  flex: 1 1 0;
   max-width: 160px;
 }
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -14,6 +14,7 @@
 
 html {
   font-size: 100%;
+  scrollbar-gutter: stable;
 }
 
 body {

--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -13,20 +13,22 @@ export function DashboardPage() {
   return (
     <div className={styles.container}>
       {user?.email_missing && <EmailPromptBanner />}
-      <SectionTitle>進行中</SectionTitle>
       {isLoading && <div className={styles.loading}>読み込み中...</div>}
       {error && <div className={styles.error}>{error}</div>}
       {!isLoading && !error && records.length === 0 && <DashboardEmptyState />}
       {!isLoading && records.length > 0 && (
-        <div className={styles.list}>
-          {records.map((record) => (
-            <WatchingListItem
-              key={record.id}
-              record={record}
-              onAction={() => void handleAction(record)}
-            />
-          ))}
-        </div>
+        <>
+          <SectionTitle>進行中</SectionTitle>
+          <div className={styles.list}>
+            {records.map((record) => (
+              <WatchingListItem
+                key={record.id}
+                record={record}
+                onAction={() => void handleAction(record)}
+              />
+            ))}
+          </div>
+        </>
       )}
     </div>
   )

--- a/frontend/src/pages/LibraryPage/useLibrary.test.tsx
+++ b/frontend/src/pages/LibraryPage/useLibrary.test.tsx
@@ -22,12 +22,10 @@ describe('useLibrary', () => {
     vi.mocked(recordsApi.getAll).mockResolvedValue(mockResponse)
   })
 
-  it('初回アクセス（パラメータなし）で status=watching がデフォルト', async () => {
+  it('初回アクセス（パラメータなし）で status=all がデフォルト', async () => {
     renderHook(() => useLibrary(), { wrapper: wrapper(['/library']) })
     await waitFor(() => {
-      expect(recordsApi.getAll).toHaveBeenCalledWith(
-        expect.objectContaining({ status: 'watching' }),
-      )
+      expect(recordsApi.getAll).toHaveBeenCalledWith(expect.objectContaining({ status: undefined }))
     })
   })
 

--- a/frontend/src/pages/LibraryPage/useLibrary.ts
+++ b/frontend/src/pages/LibraryPage/useLibrary.ts
@@ -23,13 +23,13 @@ export function useLibrary() {
     error: null,
   })
 
-  // 初回アクセス時にデフォルトの status=watching を設定
+  // 初回アクセス時にデフォルトの status=all を設定
   useEffect(() => {
     if (!searchParams.has('status')) {
       setSearchParams(
         (prev) => {
           const next = new URLSearchParams(prev)
-          next.set('status', 'watching')
+          next.set('status', 'all')
           return next
         },
         { replace: true },


### PR DESCRIPTION
## Summary
- 記録がないときに「進行中」ヘッダーを非表示にする
- はじめましょうカードのステップ幅を均等化して中央寄せを改善
- `scrollbar-gutter: stable` でスクロールバー表示時のレイアウトずれを防止
- マイライブラリのデフォルトフィルタを「視聴中」→「すべて」に変更

## Test plan
- [x] フロントエンドテスト全パス（214件）
- [x] バックエンドテスト全パス（180件）
- [x] ESLint / Prettier / RuboCop パス
- [x] ダッシュボード空状態の中央寄せを目視確認
- [x] 検索ページでスクロールバー表示時にレイアウトがずれないことを確認
- [x] マイライブラリのデフォルトが「すべて」になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)