### PR TITLE
fix: ログイン後の白画面を修正（assume_ssl有効化 + ローディング表示追加）

### DIFF
--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -18,8 +18,9 @@ Rails.application.configure do
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.asset_host = "http://assets.example.com"
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
-  # config.assume_ssl = true
+  # CloudFrontがSSLを終端し、EC2にはHTTPで転送するため、
+  # Railsにリバースプロキシ経由のSSL接続であることを認識させる
+  config.assume_ssl = true
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -23,6 +23,12 @@
   font-size: var(--font-size-label);
 }
 
+.loading {
+  text-align: center;
+  padding: var(--spacing-xl);
+  color: var(--color-text-muted);
+}
+
 /* ボトムタブバー分の余白（スマホのみ） */
 @media (max-width: 768px) {
   .authenticatedContent {

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -26,6 +26,16 @@ beforeEach(() => {
 })
 
 describe('App', () => {
+  it('ロード中は読み込み中テキストを表示する', () => {
+    mockFetch.mockReset()
+    // fetchを未解決のまま保留してisLoading状態を維持
+    mockFetch.mockReturnValueOnce(new Promise(() => {}))
+
+    render(<App />)
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+  })
+
   it('未認証時にログインページが表示される', async () => {
     render(<App />)
     // ログインページにある「アカウントを作成」リンクで確認

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,7 +22,7 @@ import { AccountSettingsPage } from './pages/AccountSettingsPage/AccountSettings
 function RootRedirect() {
   const { isAuthenticated, isLoading } = useAuth()
 
-  if (isLoading) return null
+  if (isLoading) return <div className={appStyles.loading}>読み込み中...</div>
 
   return isAuthenticated ? <Navigate to="/dashboard" replace /> : <Navigate to="/login" replace />
 }
@@ -31,7 +31,7 @@ function RootRedirect() {
 function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const { user, logout } = useAuth()
 
-  if (!user) return null
+  if (!user) return <div className={appStyles.loading}>読み込み中...</div>
 
   return (
     <>

--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.module.css
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.module.css
@@ -1,0 +1,5 @@
+.loading {
+  text-align: center;
+  padding: var(--spacing-xl);
+  color: var(--color-text-muted);
+}

--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -12,6 +12,31 @@ beforeEach(() => {
 })
 
 describe('ProtectedRoute', () => {
+  it('ロード中は読み込み中テキストを表示する', () => {
+    // fetchを未解決のまま保留してisLoading状態を維持
+    mockFetch.mockReturnValueOnce(new Promise(() => {}))
+
+    render(
+      <MemoryRouter initialEntries={['/protected']}>
+        <AuthProvider>
+          <Routes>
+            <Route
+              path="/protected"
+              element={
+                <ProtectedRoute>
+                  <div>保護されたコンテンツ</div>
+                </ProtectedRoute>
+              }
+            />
+          </Routes>
+        </AuthProvider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument()
+    expect(screen.queryByText('保護されたコンテンツ')).not.toBeInTheDocument()
+  })
+
   it('認証済みユーザーはページを表示できる', async () => {
     // セッション確認: 認証済み
     mockFetch.mockResolvedValueOnce({

--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.tsx
@@ -1,5 +1,6 @@
 import { Navigate } from 'react-router-dom'
 import { useAuth } from '../../contexts/useAuth'
+import styles from './ProtectedRoute.module.css'
 
 // 認証が必要なルートを保護するコンポーネント
 // 未認証ユーザーはログインページにリダイレクトされる
@@ -7,7 +8,7 @@ export function ProtectedRoute({ children }: { children: React.ReactNode }) {
   const { isAuthenticated, isLoading } = useAuth()
 
   if (isLoading) {
-    return null
+    return <div className={styles.loading}>読み込み中...</div>
   }
 
   if (!isAuthenticated) {


### PR DESCRIPTION
本番環境でログイン後に白画面が表示される障害を修正。

根本原因: PR #51でセッションCookieにsecure: trueを追加したが、
config.assume_sslが無効のままだった。CloudFront(HTTPS)→EC2(HTTP)構成で
RailsがSSL接続を認識できず、Secure Cookieの処理が破綻していた。

修正内容:
- config.assume_ssl = trueを有効化（本番環境のSSLプロキシ対応）
- ProtectedRoute/AuthenticatedLayout/RootRedirectのreturn nullを
  ローディング表示に変更（白画面の防御的対策）
- ローディング状態のテストを追加

https://claude.ai/code/session_01NxuQuX9etECyrrZWeHC9XT