### PR TITLE
fix: EC2/RDSにlifecycle ignore_changesを追加

### DIFF
--- a/infra/ec2.tf
+++ b/infra/ec2.tf
@@ -37,6 +37,9 @@ resource "aws_instance" "api" {
     volume_type = "gp3"
   }
 
+  # AMIの更新でインスタンスが破壊・再作成されるのを防ぐ
+  lifecycle { ignore_changes = [ami, user_data] }
+
   tags = { Name = "${var.project_name}-api" }
 }
 

--- a/infra/rds.tf
+++ b/infra/rds.tf
@@ -39,5 +39,8 @@ resource "aws_db_instance" "main" {
   # パフォーマンスインサイト（無料枠内）
   performance_insights_enabled = true
 
+  # terraform apply時にパスワードが意図せず変更されるのを防ぐ
+  lifecycle { ignore_changes = [password] }
+
   tags = { Name = "${var.project_name}-db" }
 }


### PR DESCRIPTION
## Summary
- EC2: AMI更新によるインスタンス破壊・再作成を防止（`ignore_changes = [ami, user_data]`）
- RDS: terraform apply時のパスワード意図せず変更を防止（`ignore_changes = [password]`）

## 背景
terraform planで、AMIの新バージョンが出たためEC2が`destroy and then create replacement`になっていた。本番サーバーが停止するため、lifecycle guardを追加。

## Test plan
- [ ] `terraform plan` で EC2/RDS の変更が消えていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)