### PR TITLE
fix: ホーム画面の+1話ボタンが最終話を超えてクリックできるバグを修正

### DIFF
--- a/docs/superpowers/plans/2026-03-29-episode-overclick-guard.md
+++ b/docs/superpowers/plans/2026-03-29-episode-overclick-guard.md
@@ -1,0 +1,33 @@
+# 実装プラン: エピソード上限超過クリック防止ガード
+
+**Issue:** #78
+**スペック:** `docs/superpowers/specs/2026-03-29-episode-overclick-guard-design.md`
+
+## タスク
+
+### Task 1: テスト追加（TDD: Red）
+
+**ファイル:** `frontend/src/hooks/useDashboard.test.ts`
+
+上限到達時に `handleAction` がAPIを呼ばないことを確認するテストを追加する。
+
+- テストケース: `current_episode` が `total_episodes` と同じ場合、`recordsApi.update` が呼ばれない
+- テストケース: `current_episode` が `total_episodes` 未満の場合は通常通り動作する（既存テストで担保されている可能性あり、確認して不足があれば追加）
+
+### Task 2: ガード実装（TDD: Green）
+
+**ファイル:** `frontend/src/hooks/useDashboard.ts`
+
+`handleAction` の `hasEpisodes(mediaType)` 分岐の冒頭に上限チェックを追加。
+
+```typescript
+const totalEpisodes = record.work.total_episodes
+if (totalEpisodes !== null && record.current_episode >= totalEpisodes) {
+  return
+}
+```
+
+### Task 3: リンター・テスト確認
+
+- `npm run lint` パス確認
+- `npm run test` パス確認

--- a/docs/superpowers/specs/2026-03-29-episode-overclick-guard-design.md
+++ b/docs/superpowers/specs/2026-03-29-episode-overclick-guard-design.md
@@ -1,0 +1,60 @@
+# エピソード上限超過クリック防止ガード
+
+## 概要
+
+ホーム画面の「+1話」ボタンを連打した際、最終話を超えてクリックできてしまうバグを修正する。
+
+## 現状の問題
+
+### 再現手順
+
+1. ホーム画面で視聴中のアニメ（例: 全12話）の「+1話」を連打
+2. 12話（最終話）に到達後もクリックできてしまう
+3. バックエンドのバリデーション（`current_episode > total_episodes`）でエラー
+4. 「進捗の更新に失敗しました」エラーメッセージが表示される
+5. レコードは自動完了でリストから消えているため、エラーだけが残る空画面になる
+
+### 原因
+
+`useDashboard.ts` の `handleAction` 関数に上限チェックがない。
+
+- `ProgressControl` コンポーネント（作品詳細ページで使用）にはガードがある（`canIncrement = total === null || current < total`）
+- しかしホーム画面の `WatchingListItem` は `handleAction` を直接呼び出しており、同等のガードがない
+
+## 修正方針
+
+### やること
+
+- `handleAction` の冒頭で `current_episode >= total_episodes` の場合に早期リターンするガードを追加
+
+### やらないこと
+
+- 連打防止（debounce / throttle）→ ユーザーが5話→10話まで連打で追加したいケースを妨げるため
+- API通信中のボタン無効化 → 同上の理由
+- ボタンのUI変更（ラベル変更・disabled表示）→ スコープ外
+
+## 修正対象ファイル
+
+| ファイル | 変更内容 |
+|---------|---------|
+| `frontend/src/hooks/useDashboard.ts` | `handleAction` に上限チェック追加 |
+| `frontend/src/hooks/useDashboard.test.ts` | 上限超過時にAPIが呼ばれないテスト追加 |
+
+## 修正ロジック
+
+```typescript
+// handleAction 内、hasEpisodes(mediaType) が true の場合
+const totalEpisodes = record.work.total_episodes
+if (totalEpisodes !== null && record.current_episode >= totalEpisodes) {
+  return // 上限に達しているので何もしない
+}
+```
+
+## ガード条件の詳細
+
+| current_episode | total_episodes | 結果 |
+|----------------|---------------|------|
+| 11 | 12 | ✅ 許可（12にインクリメント → 自動完了） |
+| 12 | 12 | ❌ ブロック（既に上限） |
+| 13 | 12 | ❌ ブロック（上限超過、通常到達しない） |
+| 5 | null | ✅ 許可（上限なし） |

--- a/frontend/src/hooks/useDashboard.test.ts
+++ b/frontend/src/hooks/useDashboard.test.ts
@@ -67,6 +67,49 @@ describe('useDashboard', () => {
     expect(recordsApi.update).toHaveBeenCalledWith(1, { current_episode: 13 })
   })
 
+  it('handleAction: current_episodeがtotal_episodesに達している場合はAPIを呼ばない', async () => {
+    const atLimitRecords = [
+      {
+        ...mockRecords[0],
+        current_episode: 25,
+        work: { ...mockRecords[0].work, total_episodes: 25 },
+      },
+    ]
+    vi.mocked(recordsApi.getAll).mockResolvedValue({ records: atLimitRecords })
+    const { result } = renderHook(() => useDashboard())
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    await act(async () => {
+      await result.current.handleAction(atLimitRecords[0])
+    })
+    expect(recordsApi.update).not.toHaveBeenCalled()
+    // current_episodeが変わっていないことも確認
+    expect(result.current.records[0].current_episode).toBe(25)
+  })
+
+  it('handleAction: total_episodesがnullの場合は制限なくインクリメントできる', async () => {
+    const noLimitRecords = [
+      {
+        ...mockRecords[0],
+        current_episode: 100,
+        work: { ...mockRecords[0].work, total_episodes: null },
+      },
+    ]
+    vi.mocked(recordsApi.getAll).mockResolvedValue({ records: noLimitRecords })
+    vi.mocked(recordsApi.update).mockResolvedValue({
+      record: { ...noLimitRecords[0], current_episode: 101 },
+    })
+    const { result } = renderHook(() => useDashboard())
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false)
+    })
+    await act(async () => {
+      await result.current.handleAction(noLimitRecords[0])
+    })
+    expect(recordsApi.update).toHaveBeenCalledWith(1, { current_episode: 101 })
+  })
+
   it('エラー時にエラーメッセージを設定する', async () => {
     vi.mocked(recordsApi.getAll).mockRejectedValue(new Error('Network error'))
     const { result } = renderHook(() => useDashboard())

--- a/frontend/src/hooks/useDashboard.ts
+++ b/frontend/src/hooks/useDashboard.ts
@@ -29,6 +29,12 @@ export function useDashboard() {
     const mediaType = record.work.media_type
 
     if (hasEpisodes(mediaType)) {
+      // 上限に達している場合は何もしない（連打で超過するのを防止）
+      const totalEpisodes = record.work.total_episodes
+      if (totalEpisodes !== null && record.current_episode >= totalEpisodes) {
+        return
+      }
+
       const newEpisode = record.current_episode + 1
       setRecords((prev) =>
         prev.map((r) => (r.id === record.id ? { ...r, current_episode: newEpisode } : r)),


### PR DESCRIPTION
## Summary
- ホーム画面の「+1話」ボタン連打で最終話を超えてクリックでき、バリデーションエラーが表示されるバグを修正
- `useDashboard.handleAction` に上限チェック（`current_episode >= total_episodes` で早期リターン）を追加
- 連打でサクサク追加する操作は妨げず、上限超過のみ防止

Closes #78

## Test plan
- [x] 上限到達時にAPIが呼ばれないテスト追加
- [x] `total_episodes` が null の場合は制限なくインクリメントできるテスト追加
- [x] 既存テスト全パス（RSpec 333件 + Vitest 339件）
- [x] ESLint + Prettier パス
- [x] 手動確認: 最終話到達後にクリックしてもエラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)