### PR TITLE
docs: recolly-git-rules に再レビュー依頼フロー (@claude メンション) を明記

### DIFF
--- a/.claude/skills/recolly-git-rules/SKILL.md
+++ b/.claude/skills/recolly-git-rules/SKILL.md
@@ -31,19 +31,57 @@ refactor: 認証ロジックを整理
 
 ## コードレビュー
 
+### 初回レビュー（自動）
+
+PR を open すると、`.github/workflows/claude-code-review.yml` により Claude Code Review が自動で走る。トリガーは `pull_request: opened / ready_for_review / reopened` イベントのみ。
+
+### 再レビュー（手動、@claude メンションで発動）
+
+**subsequent push では自動レビューは走らない**。これは設計上の意図：
+
+- 再レビューのいたちごっこ（ping-pong）を防ぐ
+- 些細な修正まで毎回レビューすると API コストと待ち時間が無駄
+- 「人間が見てほしいと判断したタイミング」で走らせる方がノイズが少ない
+
+再レビューが必要になったら、PR のコメント欄に `@claude` メンションして依頼する。これで `.github/workflows/claude.yml` が発動し、コメントの指示内容に従って Claude がアクションする。
+
+#### 再レビュー依頼コメントの例
+
+**一般的な再レビュー依頼**:
+
+```
+@claude 直近のコミットを再レビューしてください
+```
+
+**特定ファイル / 観点を限定**:
+
+```
+@claude Gemfile の変更だけ見てください。依存 gem の順序が正しいか、バージョン固定が妥当か確認してほしい
+```
+
+**指摘への返答と修正依頼**（claude.yml は修正コミットも作れる）:
+
+```
+@claude 指摘ありがとうございます。L42 の nil ガードを追加してください
+```
+
 ### フロー
 
 1. ローカルで実装 + テスト + コミット
-2. `git push` + PR作成
-3. **Claude Code Review が自動でPRをレビュー**（GitHub Actions）
-4. 指摘事項を解消（ローカルのClaude Code または PR上で @claude メンションで修正）
-5. CI全パス + レビュー指摘解消 → マージ
+2. `git push` + PR 作成
+3. **Claude Code Review が初回レビュー**（自動、`claude-code-review.yml`）
+4. 指摘事項があれば：
+   - **ローカルで修正** → 追加コミット push（自動レビューは走らない）
+   - **または PR コメントで @claude メンション** → Claude が修正コミット（`claude.yml`）
+5. 追加コミット後に再レビューを受けたい場合のみ、PR コメントで `@claude 再レビューして` と依頼
+6. CI 全パス + レビュー指摘解消 → マージ
 
 ### ルール
 
-- 全PRにClaude Code Reviewを必須とする（CI経由で自動実行）
+- 全 PR の **初回に** Claude Code Review を必須とする（CI 経由で自動実行）
 - レビュー指摘を全て解消してからマージする
-- レビュー指摘の修正はローカルのClaude Code または PR上で @claude メンションで行う
+- **subsequent push で自動レビューは走らない**（意図的）。必要なら明示的に `@claude` で再依頼
+- レビュー指摘の修正はローカルの Claude Code または PR 上で `@claude` メンションで行う
 
 ### レビュー観点
 
@@ -59,7 +97,8 @@ refactor: 認証ロジックを整理
 
 ### 設定ファイル
 
-- ワークフロー: `.github/workflows/claude-code-review.yml`
+- 初回レビュー: `.github/workflows/claude-code-review.yml`（`pull_request: opened / ready_for_review / reopened`）
+- オンデマンドレビュー: `.github/workflows/claude.yml`（`@claude` メンションで発動）
 
 ## PR前セルフチェック
 

--- a/.claude/skills/recolly-git-rules/SKILL.md
+++ b/.claude/skills/recolly-git-rules/SKILL.md
@@ -43,14 +43,70 @@ PR を open すると、`.github/workflows/claude-code-review.yml` により Cla
 - 些細な修正まで毎回レビューすると API コストと待ち時間が無駄
 - 「人間が見てほしいと判断したタイミング」で走らせる方がノイズが少ない
 
-再レビューが必要になったら、PR のコメント欄に `@claude` メンションして依頼する。これで `.github/workflows/claude.yml` が発動し、コメントの指示内容に従って Claude がアクションする。
+再レビューは PR コメントで `@claude` メンションして依頼する。これで `.github/workflows/claude.yml` が発動し、コメントの指示内容に従って GH Actions 上の Claude がアクションする。
 
-#### 再レビュー依頼コメントの例
+### レビュー対応のフィードバックループ（推奨運用）
+
+GH Actions Claude の指摘に対する対応は、以下の分業で進める：
+
+```
+[1] PR 作成
+     ↓
+[2] claude-code-review.yml が初回レビュー → 指摘コメントを投稿
+     ↓
+[3] IK さんが指摘内容を local Claude（この環境の Claude Code）に共有
+     ↓
+[4] local Claude が指摘の技術的妥当性を検証（← 重要なゲート）
+     │   - 指摘は正しいか？
+     │   - 本当に修正が必要か？
+     │   - 指摘が誤りなら IK に説明して反論検討
+     │   ※ superpowers:receiving-code-review の精神に沿って「盲従しない」
+     ↓
+[5] 妥当と判断した指摘のみ修正コミット + push
+     ↓
+[6] local Claude が gh pr comment で「修正報告 + @claude メンション」を投稿
+     │   例: 「指摘の X と Y を Z で修正しました。@claude 再確認お願いします」
+     ↓
+[7] claude.yml が発動 → GH Actions Claude が差分を再確認
+     ↓
+[8] OK ならマージ（IK さん判断）、追加指摘があれば [3] に戻る
+```
+
+**役割分担**:
+
+| ステップ | 担当 |
+|---|---|
+| 指摘の技術的妥当性検証 | **local Claude**（盲従ゲートキーパー） |
+| 修正実装 | local Claude |
+| `@claude` メンションコメントの投稿 | **local Claude**（`gh pr comment` で代行） |
+| マージ判断 | IK さん |
+| レビュー実行 | GH Actions Claude |
+
+**IK さんの手間**:
+
+- 指摘内容を local Claude に共有する（スクショ貼付 or 内容を伝える）
+- 「修正 OK、`@claude` 再依頼して」と指示する
+- マージボタンを押す
+
+**IK さんがやらないこと**:
+
+- `@claude` という文字列を手でタイプしてコメントを書く（local Claude が `gh pr comment` で代行）
+- 指摘を全部そのまま修正に反映する（妥当性は local Claude が先に検証）
+
+### 再レビュー依頼コメントの例（local Claude が `gh pr comment` で投稿）
 
 **一般的な再レビュー依頼**:
 
 ```
 @claude 直近のコミットを再レビューしてください
+```
+
+**修正報告とセットでの再確認依頼**:
+
+```
+指摘ありがとうございます。L42 の nil ガードと L78 のエラーハンドリングを追加しました（commit abc1234）。
+
+@claude 修正内容が意図通りになっているか再確認お願いします。
 ```
 
 **特定ファイル / 観点を限定**:
@@ -59,29 +115,21 @@ PR を open すると、`.github/workflows/claude-code-review.yml` により Cla
 @claude Gemfile の変更だけ見てください。依存 gem の順序が正しいか、バージョン固定が妥当か確認してほしい
 ```
 
-**指摘への返答と修正依頼**（claude.yml は修正コミットも作れる）:
-
-```
-@claude 指摘ありがとうございます。L42 の nil ガードを追加してください
-```
-
-### フロー
+### フロー（簡略版）
 
 1. ローカルで実装 + テスト + コミット
 2. `git push` + PR 作成
-3. **Claude Code Review が初回レビュー**（自動、`claude-code-review.yml`）
-4. 指摘事項があれば：
-   - **ローカルで修正** → 追加コミット push（自動レビューは走らない）
-   - **または PR コメントで @claude メンション** → Claude が修正コミット（`claude.yml`）
-5. 追加コミット後に再レビューを受けたい場合のみ、PR コメントで `@claude 再レビューして` と依頼
-6. CI 全パス + レビュー指摘解消 → マージ
+3. **claude-code-review.yml が初回レビュー**（自動）
+4. 指摘があれば上記「レビュー対応のフィードバックループ」に従って対応
+5. CI 全パス + レビュー指摘解消 → マージ
 
 ### ルール
 
 - 全 PR の **初回に** Claude Code Review を必須とする（CI 経由で自動実行）
 - レビュー指摘を全て解消してからマージする
-- **subsequent push で自動レビューは走らない**（意図的）。必要なら明示的に `@claude` で再依頼
-- レビュー指摘の修正はローカルの Claude Code または PR 上で `@claude` メンションで行う
+- **subsequent push で自動レビューは走らない**（意図的）。必要なら `@claude` で明示的に再依頼
+- 指摘への対応は **local Claude が技術的妥当性を検証** してから反映する（盲従禁止）
+- 再レビュー依頼の `@claude` コメント投稿は **local Claude が `gh pr comment` で代行** する（IK さんが手でタイプしなくて良い）
 
 ### レビュー観点
 


### PR DESCRIPTION
## Summary

PR #116 の作業中に判明した「subsequent push では自動レビューが走らない」という設計意図を `recolly-git-rules` スキルに明文化する。

### 背景

PR #116 の Gemfile 並び替え修正を push した際、IK が「再レビューが走っていない」ことに気付いた。これは \`.github/workflows/claude-code-review.yml\` のトリガーが \`pull_request: opened, ready_for_review, reopened\` だけに制限されているため意図通りの挙動だが、スキル内に明記されていなかった。

設計意図：

- 再レビューのいたちごっこ（ping-pong）を防ぐ
- 些細な修正まで毎回レビューすると API コストと待ち時間が無駄
- 「人間が見てほしい」と判断したタイミングで明示的に走らせる方がノイズが少ない

### 変更内容

\`.claude/skills/recolly-git-rules/SKILL.md\` のコードレビュー節を再構成：

- **「初回レビュー（自動）」** と **「再レビュー（手動）」** を明確に分離
- \`claude-code-review.yml\` のトリガーが \`opened / ready_for_review / reopened\` のみであることを明記
- subsequent push では自動レビューが走らないことを明文化（設計意図付き）
- **再レビュー依頼は PR コメントで \`@claude\` メンション** して \`claude.yml\` を発動する手順を追加
- 再レビュー依頼コメントの例を 3 パターン追加：
  - 一般的な再レビュー
  - 特定ファイル / 観点を限定
  - 指摘への返答と修正依頼
- 設定ファイル欄に \`claude.yml\`（オンデマンドレビュー）も追記

## Test Plan

ドキュメントのみの変更で実行コードに影響なし。

- [x] Markdown の構文エラーがないこと（手元で VS Code プレビュー確認）
- [x] 既存の「フロー」「ルール」「レビュー観点」セクションとの整合性
- [ ] （任意）マージ後に新しい PR を作成して、初回自動レビューが走ることを確認
- [ ] （任意）マージ後に \`@claude\` メンションコメントを投稿して \`claude.yml\` が発動することを確認

## 関連

- PR #115 (PR-B1 SES 設定)
- PR #116 (SES hotfix) ← ここで設計意図の明文化漏れが発覚

🤖 Generated with [Claude Code](https://claude.com/claude-code)