### PR TITLE
fix(infra): SES IAM ポリシーの Resource を identity/* に拡張

### DIFF
--- a/docs/adr/0037-ses-api方式でメール送信.md
+++ b/docs/adr/0037-ses-api方式でメール送信.md
@@ -110,6 +110,39 @@ PR #104 の動作確認中、オーナーアカウントがロックアウトさ
 - メール本文の日本語化（PR-B2 #107）
 - DMARC ポリシーの強化（`p=none` → `p=quarantine` → `p=reject`）（運用安定後）
 
+## 実装時の学び（ホットフィックス履歴）
+
+### 学び 1: aws-sdk-rails 5.x は機能別 gem 分離（PR #116 で対応）
+
+PR #115 の初回実装で `aws-sdk-rails` + `aws-sdk-sesv2` だけ追加したら、`Invalid delivery method :ses_v2` エラー。aws-sdk-rails 5.x は本体が薄い Railtie 層のみで、SES ActionMailer 機能は `aws-actionmailer-ses` という別 gem に切り出されている。公式 README を読み飛ばさないこと。
+
+### 学び 2: SES v2 + raw content + サンドボックスは受信者 identity の IAM 権限も必要（PR #118 で対応）
+
+PR #116 で `:ses_v2` が使えるようになった後、動作確認で以下のエラー：
+
+```
+Aws::SESV2::Errors::AccessDeniedException
+User ... is not authorized to perform `ses:SendRawEmail` on resource
+`arn:aws:ses:ap-northeast-1:*:identity/<verified-recipient>@gmail.com`
+```
+
+**根本原因**:
+- SES v2 の `SendEmail` API は raw MIME content を渡すとき内部的に `ses:SendRawEmail` 権限を要求する（v1 互換の挙動）
+- **サンドボックスモードでは、送信元 identity だけでなく受信者として verify された email identity に対する権限も必要**
+- 例: 送信元 `noreply@recolly.net`（domain identity）+ 受信者 `user@gmail.com`（email identity、Step 4 で verify）の両方に `ses:SendRawEmail` が必要
+
+**対応**:
+
+当初の iam.tf は `resources = ["arn:aws:ses:${var.aws_region}:*:identity/${var.domain_name}"]` で domain identity のみ許可していたが、`identity/*` に広げた。個別の verified email identity を毎回ポリシーに追加するのは非現実的なため。
+
+**セキュリティ評価（妥当性の検証）**:
+
+- EC2 インスタンスロールは EC2 からのみ assume 可能
+- このアカウントで verify されたドメインは `recolly.net` のみ（今後ドメイン追加しない限り、事実上 recolly.net 経由しか送れない）
+- サンドボックスが解除されても SES の rate limit が効く
+- `ses:SendEmail` / `ses:SendRawEmail` のみ許可で、他の SES API（設定変更等）は引き続き拒否
+- 実質的なリスクは `identity/recolly.net` 限定と同等
+
 ## 参考
 
 - AWS SES v2 公式ドキュメント: <https://docs.aws.amazon.com/ses/latest/dg/send-email-api.html>

--- a/infra/iam.tf
+++ b/infra/iam.tf
@@ -72,8 +72,21 @@ resource "aws_iam_role_policy_attachment" "ec2_s3_images" {
   policy_arn = aws_iam_policy.ec2_s3_images.arn
 }
 
-# EC2がSES経由でメール送信する権限（ADR-0037, Issue #108）
-# Resource を recolly.net の identity に限定（最小権限原則）
+# EC2がSES経由でメール送信する権限（ADR-0037, Issue #108 / #118）
+#
+# Resource が "identity/*" と広く見えるが、以下の理由で実質的な権限拡大は最小:
+# - EC2 インスタンスロール自体は EC2 インスタンスからのみ assume 可能
+# - このアカウントで verify されたドメインは recolly.net のみ
+# - 検証済みメールアドレスは SES console で明示的に追加したものに限る
+# - SES サンドボックスモードが送信先を検証済みアドレスに制限する
+#
+# なぜ identity/recolly.net だけでは不十分か:
+# SES v2 の SendEmail API は raw MIME content を渡すとき、内部的に
+# ses:SendRawEmail 権限を要求する。サンドボックスモードでは送信元 identity
+# (recolly.net) だけでなく、受信者として verify した email identity にも
+# 権限が必要となる (例: identity/your-verified@gmail.com)。
+# 個別メアドごとにポリシー追加するのは現実的でないため、同一アカウント内の
+# SES identity 全体に許可する形に広げる。
 data "aws_iam_policy_document" "ec2_ses" {
   statement {
     actions = [
@@ -81,7 +94,7 @@ data "aws_iam_policy_document" "ec2_ses" {
       "ses:SendRawEmail",
     ]
     resources = [
-      "arn:aws:ses:${var.aws_region}:*:identity/${var.domain_name}",
+      "arn:aws:ses:${var.aws_region}:*:identity/*",
     ]
   }
 }


### PR DESCRIPTION
## Summary

PR #116 (aws-actionmailer-ses 追加) 後の動作確認で判明した IAM 権限エラーを修正する。

## 発覚経緯

PR #116 マージ後、EC2 の rails console で \`send_reset_password_instructions\` を実行したところ以下のエラー：

\`\`\`
Aws::SESV2::Errors::AccessDeniedException
User \`arn:aws:sts::...:assumed-role/recolly-ec2-role/...\` is not authorized
to perform \`ses:SendRawEmail\` on resource
\`arn:aws:ses:ap-northeast-1:...:identity/<verified-recipient>@gmail.com\`
\`\`\`

診断で確認済み：

- ✅ \`:ses_v2\` delivery method は正しく登録されている（PR #116 の gem 追加が効いた）
- ❌ 送信時に IAM 権限チェックで拒否される

## 根本原因

**SES v2 の SendEmail API は raw MIME content を渡すとき、内部的に \`ses:SendRawEmail\` 権限を要求** する（v1 互換の挙動）。さらに **サンドボックスモードでは、送信元 identity だけでなく受信者として verify された email identity に対する権限も必要** となる。

PR #115 で書いた当初の \`infra/iam.tf\` は送信元 identity のみに限定：

\`\`\`hcl
resources = [
  "arn:aws:ses:\${var.aws_region}:*:identity/\${var.domain_name}",
  # = arn:aws:ses:ap-northeast-1:*:identity/recolly.net のみ
]
\`\`\`

これだと受信者 identity (IK の個人メアド、Step 4 で verify) への権限チェックで失敗する。

## 修正内容

### \`infra/iam.tf\`

Resource を同一アカウント内の全 SES identity に拡張：

\`\`\`diff
 data "aws_iam_policy_document" "ec2_ses" {
   statement {
     actions = [
       "ses:SendEmail",
       "ses:SendRawEmail",
     ]
     resources = [
-      "arn:aws:ses:\${var.aws_region}:*:identity/\${var.domain_name}",
+      "arn:aws:ses:\${var.aws_region}:*:identity/*",
     ]
   }
 }
\`\`\`

コメントも更新して、以下を明記：

- なぜ広く見えても実質的リスクが小さいかの理由
- なぜ \`identity/recolly.net\` だけでは不十分かの解説

### \`docs/adr/0037-ses-api方式でメール送信.md\`

「実装時の学び（ホットフィックス履歴）」セクションを新規追加：

- 学び 1: aws-sdk-rails 5.x の gem 分離（PR #116 で対応）
- 学び 2: SES v2 + raw content + サンドボックスで受信者 identity 権限が必要（本 PR で対応）

## セキュリティ評価

\`identity/*\` に広げても実質的なリスク拡大はほぼゼロ：

| 観点 | 評価 |
|---|---|
| EC2 ロール漏洩時の被害範囲 | EC2 ロールは EC2 インスタンスからのみ assume 可能（既存 \`ec2_assume_role\` ポリシーで制限） |
| 他ドメインからの送信 | このアカウントに verify されたドメインは \`recolly.net\` のみ。今後 verify しない限り事実上 recolly.net 経由しか送れない |
| スパム送信の踏み台化 | サンドボックスモード → 検証済みアドレスにしか送れない。解除後も SES の rate limit が効く |
| 権限スコープ | \`ses:SendEmail\` / \`ses:SendRawEmail\` のみ許可。他の SES API（設定変更等）は引き続き拒否 |

実質的には \`identity/recolly.net\` 限定と同等のセキュリティレベル。

## Test Plan

### CI 自動検証

- [x] \`terraform fmt\` clean
- [x] \`terraform validate\` Success

### マージ後の手動確認（IK さん）

- [ ] \`cd infra/ && terraform plan\` で IAM ポリシー更新の差分のみ出ることを確認（1 to change）
- [ ] \`terraform apply\`
- [ ] EC2 で \`sudo docker exec -it recolly-api bundle exec rails console\`
- [ ] \`User.find_by(email: '<verified@example.com>').send_reset_password_instructions\`
- [ ] IK の受信箱にパスワードリセットメールが届くことを確認
- [ ] メール本文内のリセットリンクが \`https://recolly.net/...\` になっていることを確認

**注**: Docker イメージの再ビルドは不要（インフラのみの変更）。GitHub Actions の CD は走るが、Rails コードに変更がないためデプロイ内容は実質同じ。

## 関連

- PR #115 (PR-B1 本体)
- PR #116 (aws-actionmailer-ses 追加)
- Issue #108
- ADR-0037

Refs #108 #115 #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)