### PR TITLE
feat: 認証エラー時のアクション誘導カードを追加

### DIFF
--- a/docs/superpowers/plans/2026-04-11-auth-error-action-cards.md
+++ b/docs/superpowers/plans/2026-04-11-auth-error-action-cards.md
@@ -1,0 +1,630 @@
+# 認証エラー時のアクション誘導カード 実装プラン
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** OAuthButtons と AccountSettingsPage のエラー表示にアクションボタン付きカード（ActionErrorCard）を追加し、ユーザーが次に取るべき操作を明示する。
+
+**Architecture:** 共通コンポーネント `ActionErrorCard` を `components/ui/` に作成し、OAuthButtons（#113）と AccountSettingsPage（#114）の両方から使う。各コンポーネントでは `ApiError.code` を保持するよう state を拡張し、エラーコード別にカード表示を分岐する。
+
+**Tech Stack:** React 19 / TypeScript / Vitest + React Testing Library / CSS Modules + tokens.css
+
+---
+
+## ファイル構成
+
+| 区分 | ファイル | 役割 |
+|------|---------|------|
+| 新規作成 | `frontend/src/components/ui/ActionErrorCard/ActionErrorCard.tsx` | 共通エラーカードコンポーネント |
+| 新規作成 | `frontend/src/components/ui/ActionErrorCard/ActionErrorCard.module.css` | カードのスタイル |
+| 新規作成 | `frontend/src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx` | 単体テスト |
+| 変更 | `frontend/src/components/OAuthButtons/OAuthButtons.tsx` | error stateを拡張、ActionErrorCard表示 |
+| 変更 | `frontend/src/components/OAuthButtons/OAuthButtons.test.tsx` | エラーコード別テスト追加 |
+| 変更 | `frontend/src/pages/AccountSettingsPage/useAccountSettings.ts` | providerErrorを型拡張 |
+| 変更 | `frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx` | ActionErrorCard表示、パスワードフォームにid付与 |
+| 変更 | `frontend/src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx` | 連携解除失敗テスト追加 |
+| 変更 | `frontend/src/pages/LoginPage/LoginPage.tsx` | メールフォームにid付与 |
+
+---
+
+### Task 1: ActionErrorCard コンポーネント作成
+
+**Files:**
+- Create: `frontend/src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx`
+- Create: `frontend/src/components/ui/ActionErrorCard/ActionErrorCard.tsx`
+- Create: `frontend/src/components/ui/ActionErrorCard/ActionErrorCard.module.css`
+
+- [ ] **Step 1: テストファイルを作成**
+
+```tsx
+// frontend/src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ActionErrorCard } from './ActionErrorCard'
+
+describe('ActionErrorCard', () => {
+  it('タイトルとメッセージが表示される', () => {
+    render(<ActionErrorCard title="エラータイトル" message="エラーの説明文" />)
+
+    expect(screen.getByText('エラータイトル')).toBeInTheDocument()
+    expect(screen.getByText('エラーの説明文')).toBeInTheDocument()
+  })
+
+  it('actionLabelを渡すとボタンが表示される', () => {
+    render(
+      <ActionErrorCard
+        title="タイトル"
+        message="メッセージ"
+        actionLabel="アクションボタン"
+        onAction={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'アクションボタン' })).toBeInTheDocument()
+  })
+
+  it('actionLabelを渡さないとボタンが表示されない', () => {
+    render(<ActionErrorCard title="タイトル" message="メッセージ" />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('ボタンクリックでonActionが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const handleAction = vi.fn()
+
+    render(
+      <ActionErrorCard
+        title="タイトル"
+        message="メッセージ"
+        actionLabel="クリック"
+        onAction={handleAction}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'クリック' }))
+    expect(handleAction).toHaveBeenCalledTimes(1)
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+Run: `cd frontend && npx vitest run src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx`
+Expected: FAIL（ActionErrorCard モジュールが存在しない）
+
+- [ ] **Step 3: コンポーネントを実装**
+
+```tsx
+// frontend/src/components/ui/ActionErrorCard/ActionErrorCard.tsx
+import { Button } from '../Button/Button'
+import styles from './ActionErrorCard.module.css'
+
+type ActionErrorCardProps = {
+  title: string
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+}
+
+export function ActionErrorCard({ title, message, actionLabel, onAction }: ActionErrorCardProps) {
+  return (
+    <div className={styles.card} role="alert">
+      <p className={styles.title}>{title}</p>
+      <p className={styles.message}>{message}</p>
+      {actionLabel && onAction && (
+        <Button variant="primary" size="sm" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: CSSモジュールを作成**
+
+```css
+/* frontend/src/components/ui/ActionErrorCard/ActionErrorCard.module.css */
+.card {
+  background-color: var(--color-error-bg);
+  border: var(--border-width-thin) var(--border-style) var(--color-error);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+  margin-top: var(--spacing-sm);
+}
+
+.title {
+  color: var(--color-error);
+  font-family: var(--font-body);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-medium);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.message {
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--font-size-meta);
+  line-height: var(--line-height-normal);
+  margin: 0 0 var(--spacing-sm) 0;
+}
+
+.message:last-child {
+  margin-bottom: 0;
+}
+```
+
+- [ ] **Step 5: テストを実行してパスを確認**
+
+Run: `cd frontend && npx vitest run src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx`
+Expected: 4 tests PASS
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/components/ui/ActionErrorCard/
+git commit -m "feat(frontend): ActionErrorCard 共通コンポーネントを追加
+
+エラーメッセージ + タイトル + アクションボタンを表示する汎用カード。
+OAuthButtons と AccountSettingsPage のエラー誘導に使用する。
+
+refs #113, #114"
+```
+
+---
+
+### Task 2: OAuthButtons にエラーコード別の ActionErrorCard を組み込む (#113)
+
+**Files:**
+- Modify: `frontend/src/components/OAuthButtons/OAuthButtons.tsx`
+- Modify: `frontend/src/components/OAuthButtons/OAuthButtons.test.tsx`
+- Modify: `frontend/src/pages/LoginPage/LoginPage.tsx`
+
+- [ ] **Step 1: OAuthButtons テストにエラーコード別のケースを追加**
+
+`OAuthButtons.test.tsx` の `sign_inモード` describe ブロック末尾に以下を追加:
+
+```tsx
+    it('email_already_registered エラー時に ActionErrorCard が表示される', async () => {
+      const { triggerCallback } = setupGoogleSdkMock()
+      mockSignIn.mockRejectedValue(
+        new ApiError(
+          'このメールアドレスは既にメール+パスワードで登録されています。メールでログインしてください',
+          409,
+          'email_already_registered',
+        ),
+      )
+
+      renderWithProviders(<OAuthButtons />)
+      await waitFor(() => expect(window.google).toBeDefined())
+      triggerCallback('dummy-id-token')
+
+      await waitFor(() => {
+        expect(screen.getByText('ログイン方法が異なります')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'メールでログイン' })).toBeInTheDocument()
+      })
+    })
+
+    it('email_registered_with_other_provider エラー時に ActionErrorCard が表示される（ボタンなし）', async () => {
+      const { triggerCallback } = setupGoogleSdkMock()
+      mockSignIn.mockRejectedValue(
+        new ApiError(
+          'このメールアドレスは既にGoogleで登録されています',
+          409,
+          'email_registered_with_other_provider',
+        ),
+      )
+
+      renderWithProviders(<OAuthButtons />)
+      await waitFor(() => expect(window.google).toBeDefined())
+      triggerCallback('dummy-id-token')
+
+      await waitFor(() => {
+        expect(screen.getByText('別のアカウントで登録済みです')).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'メールでログイン' })).not.toBeInTheDocument()
+      })
+    })
+
+    it('その他のエラーは従来通りテキスト表示', async () => {
+      const { triggerCallback } = setupGoogleSdkMock()
+      mockSignIn.mockRejectedValue(new ApiError('不明なエラー', 500))
+
+      renderWithProviders(<OAuthButtons />)
+      await waitFor(() => expect(window.google).toBeDefined())
+      triggerCallback('dummy-id-token')
+
+      await waitFor(() => {
+        expect(screen.getByText('不明なエラー')).toBeInTheDocument()
+        expect(screen.queryByText('ログイン方法が異なります')).not.toBeInTheDocument()
+      })
+    })
+```
+
+- [ ] **Step 2: テストを実行して新規テストの失敗を確認**
+
+Run: `cd frontend && npx vitest run src/components/OAuthButtons/OAuthButtons.test.tsx`
+Expected: 新規3テストが FAIL（ActionErrorCard のタイトルが表示されないため）
+
+- [ ] **Step 3: OAuthButtons.tsx を変更**
+
+`frontend/src/components/OAuthButtons/OAuthButtons.tsx` を以下のように変更:
+
+1. import に `ActionErrorCard` を追加:
+```tsx
+import { ActionErrorCard } from '../ui/ActionErrorCard/ActionErrorCard'
+```
+
+2. error state の型を変更（L34）:
+```tsx
+// 変更前:
+const [error, setError] = useState<string | null>(null)
+
+// 変更後:
+const [error, setError] = useState<{ message: string; code?: string } | null>(null)
+```
+
+3. SDK読み込みエラーの setError を修正（L55）:
+```tsx
+// 変更前:
+setError('Googleログインの読み込みに失敗しました。ページを再読み込みしてください')
+
+// 変更後:
+setError({ message: 'Googleログインの読み込みに失敗しました。ページを再読み込みしてください' })
+```
+
+4. CLIENT_ID 未定義エラーの setError を修正（L69）:
+```tsx
+// 変更前:
+setError('Googleログインが設定されていません（VITE_GOOGLE_CLIENT_ID 未定義）')
+
+// 変更後:
+setError({ message: 'Googleログインが設定されていません（VITE_GOOGLE_CLIENT_ID 未定義）' })
+```
+
+5. catch ブロック（L108-114）を変更:
+```tsx
+    } catch (err) {
+      if (err instanceof ApiError) {
+        const errorInfo = { message: err.message, code: err.code }
+        if (mode === 'link') {
+          onLinkError?.(err.message)
+        } else {
+          setError(errorInfo)
+        }
+      } else {
+        const errorInfo = { message: 'ログインに失敗しました' }
+        if (mode === 'link') {
+          onLinkError?.(errorInfo.message)
+        } else {
+          setError(errorInfo)
+        }
+      }
+    }
+```
+
+6. handleSignIn の error ケース（L131-132）を変更:
+```tsx
+      case 'error':
+        setError({ message: data.message, code: data.code })
+        break
+```
+
+7. Props に `onScrollToEmailForm` を追加（L14-20）:
+```tsx
+type OAuthButtonsProps = {
+  mode?: 'sign_in' | 'link'
+  onLinkSuccess?: (user: User) => void
+  onLinkError?: (message: string) => void
+  onScrollToEmailForm?: () => void
+}
+```
+
+8. コンポーネント引数にも追加（L27-31）:
+```tsx
+export function OAuthButtons({
+  mode = 'sign_in',
+  onLinkSuccess,
+  onLinkError,
+  onScrollToEmailForm,
+}: OAuthButtonsProps = {}) {
+```
+
+9. JSX のエラー表示部分（L150）を変更:
+```tsx
+      {error && error.code === 'email_already_registered' && (
+        <ActionErrorCard
+          title="ログイン方法が異なります"
+          message={error.message}
+          actionLabel="メールでログイン"
+          onAction={onScrollToEmailForm}
+        />
+      )}
+      {error && error.code === 'email_registered_with_other_provider' && (
+        <ActionErrorCard
+          title="別のアカウントで登録済みです"
+          message={error.message}
+        />
+      )}
+      {error && !error.code?.match(/^(email_already_registered|email_registered_with_other_provider)$/) && (
+        <p className={styles.error}>{error.message}</p>
+      )}
+```
+
+- [ ] **Step 4: LoginPage.tsx にメールフォームの id とスクロールコールバックを追加**
+
+`frontend/src/pages/LoginPage/LoginPage.tsx` を変更:
+
+1. `<form>` タグに id を追加（L70）:
+```tsx
+// 変更前:
+<form className={styles.form} onSubmit={handleSubmit}>
+
+// 変更後:
+<form id="email-login-form" className={styles.form} onSubmit={handleSubmit}>
+```
+
+2. `<OAuthButtons />` にコールバックを渡す（L139）:
+```tsx
+// 変更前:
+<OAuthButtons />
+
+// 変更後:
+<OAuthButtons
+  onScrollToEmailForm={() => {
+    const form = document.getElementById('email-login-form')
+    if (form) {
+      form.scrollIntoView({ behavior: 'smooth' })
+      const emailInput = form.querySelector<HTMLInputElement>('input[type="email"]')
+      emailInput?.focus({ preventScroll: true })
+    }
+  }}
+/>
+```
+
+- [ ] **Step 5: テストを実行してパスを確認**
+
+Run: `cd frontend && npx vitest run src/components/OAuthButtons/OAuthButtons.test.tsx`
+Expected: 全テスト PASS
+
+- [ ] **Step 6: 既存テストに影響がないか確認**
+
+Run: `cd frontend && npx vitest run src/pages/LoginPage/LoginPage.test.tsx`
+Expected: 全テスト PASS
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add frontend/src/components/OAuthButtons/OAuthButtons.tsx \
+       frontend/src/components/OAuthButtons/OAuthButtons.test.tsx \
+       frontend/src/pages/LoginPage/LoginPage.tsx
+git commit -m "feat(frontend): OAuthButtons にエラーコード別 ActionErrorCard を追加
+
+- email_already_registered: 「メールでログイン」ボタン付きカード表示
+- email_registered_with_other_provider: プロバイダ名明示カード表示
+- その他のエラー: 従来通りテキスト表示
+- LoginPage のメールフォームへスクロール＆フォーカス
+
+closes #113"
+```
+
+---
+
+### Task 3: AccountSettingsPage に連携解除失敗時の ActionErrorCard を組み込む (#114)
+
+**Files:**
+- Modify: `frontend/src/pages/AccountSettingsPage/useAccountSettings.ts`
+- Modify: `frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx`
+- Modify: `frontend/src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx`
+
+- [ ] **Step 1: AccountSettingsPage テストに連携解除失敗ケースを追加**
+
+`AccountSettingsPage.test.tsx` に以下の import と変数を追加:
+
+1. import に `userEvent` と `waitFor` を追加（L1）:
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+```
+
+2. API モック定義を変更して `accountApi.unlinkProvider` にアクセスできるようにする（L8-25 を置換）:
+```tsx
+// APIモック
+const mockUnlinkProvider = vi.fn()
+const mockSetPassword = vi.fn()
+
+vi.mock('../../lib/api', () => ({
+  accountApi: {
+    unlinkProvider: (...args: unknown[]) => mockUnlinkProvider(...args),
+    setPassword: (...args: unknown[]) => mockSetPassword(...args),
+  },
+  googleAuthApi: {
+    signIn: vi.fn(),
+    linkProvider: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    status: number
+    code?: string
+    constructor(message: string, status: number, code?: string) {
+      super(message)
+      this.name = 'ApiError'
+      this.status = status
+      this.code = code
+    }
+  },
+}))
+```
+
+3. `describe('AccountSettingsPage')` ブロック末尾に以下のテストを追加:
+
+```tsx
+  it('連携解除失敗時（last_login_method）に ActionErrorCard が表示される', async () => {
+    const user = userEvent.setup()
+    mockUser = createUser({ providers: ['google_oauth2'], has_password: true })
+    // unlinkProvider が last_login_method エラーを返す
+    const { ApiError: MockApiError } = await import('../../lib/api')
+    mockUnlinkProvider.mockRejectedValue(
+      new MockApiError(
+        '最後のログイン手段は解除できません。先にパスワードを設定するか、別のOAuthを連携してください',
+        422,
+        'last_login_method',
+      ),
+    )
+
+    renderPage()
+
+    // 「解除」ボタンをクリック
+    const unlinkButton = screen.getByRole('button', { name: '解除' })
+    await user.click(unlinkButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('解除できません')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: 'パスワードを設定する' }),
+      ).toBeInTheDocument()
+    })
+  })
+
+  it('連携解除失敗時（その他エラー）は従来通りテキスト表示', async () => {
+    const user = userEvent.setup()
+    mockUser = createUser({ providers: ['google_oauth2'], has_password: true })
+    const { ApiError: MockApiError } = await import('../../lib/api')
+    mockUnlinkProvider.mockRejectedValue(
+      new MockApiError('サーバーエラー', 500),
+    )
+
+    renderPage()
+
+    const unlinkButton = screen.getByRole('button', { name: '解除' })
+    await user.click(unlinkButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('サーバーエラー')).toBeInTheDocument()
+      expect(screen.queryByText('解除できません')).not.toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: テストを実行して新規テストの失敗を確認**
+
+Run: `cd frontend && npx vitest run src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx`
+Expected: 新規2テストが FAIL
+
+- [ ] **Step 3: useAccountSettings.ts の providerError 型を拡張**
+
+`frontend/src/pages/AccountSettingsPage/useAccountSettings.ts` を変更:
+
+1. providerError の型を変更（L19）:
+```tsx
+// 変更前:
+const [providerError, setProviderError] = useState('')
+
+// 変更後:
+const [providerError, setProviderError] = useState<{
+  message: string
+  code?: string
+} | null>(null)
+```
+
+2. handleUnlinkProvider のエラーリセット（L27）を変更:
+```tsx
+// 変更前:
+setProviderError('')
+
+// 変更後:
+setProviderError(null)
+```
+
+3. catch ブロック（L33-36）を変更:
+```tsx
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setProviderError({ message: err.message, code: err.code })
+      } else {
+        setProviderError({ message: '連携解除に失敗しました' })
+      }
+    }
+```
+
+- [ ] **Step 4: AccountSettingsPage.tsx に ActionErrorCard を組み込む**
+
+`frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx` を変更:
+
+1. import に ActionErrorCard を追加（L1付近）:
+```tsx
+import { ActionErrorCard } from '../../components/ui/ActionErrorCard/ActionErrorCard'
+```
+
+2. エラー表示部分（L43）を変更:
+```tsx
+// 変更前:
+{providerError && <p className={styles.error}>{providerError}</p>}
+
+// 変更後:
+{providerError && providerError.code === 'last_login_method' && (
+  <ActionErrorCard
+    title="解除できません"
+    message={providerError.message}
+    actionLabel="パスワードを設定する"
+    onAction={() => {
+      const form = document.getElementById('password-form')
+      if (form) {
+        form.scrollIntoView({ behavior: 'smooth' })
+        const input = form.querySelector<HTMLInputElement>('input[type="password"]')
+        input?.focus({ preventScroll: true })
+      }
+    }}
+  />
+)}
+{providerError && providerError.code !== 'last_login_method' && (
+  <p className={styles.error}>{providerError.message}</p>
+)}
+```
+
+3. パスワードセクションの form に id を追加（L101）:
+```tsx
+// 変更前:
+<form className={styles.form} onSubmit={handlePasswordSubmit}>
+
+// 変更後:
+<form id="password-form" className={styles.form} onSubmit={handlePasswordSubmit}>
+```
+
+4. onLinkError コールバックを更新（L89）:
+```tsx
+// 変更前:
+onLinkError={(message) => setProviderError(message)}
+
+// 変更後:
+onLinkError={(message) => setProviderError({ message })}
+```
+
+- [ ] **Step 5: テストを実行してパスを確認**
+
+Run: `cd frontend && npx vitest run src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx`
+Expected: 全テスト PASS
+
+- [ ] **Step 6: 全テストを実行して回帰がないか確認**
+
+Run: `cd frontend && npx vitest run`
+Expected: 全テスト PASS
+
+- [ ] **Step 7: ESLint を実行**
+
+Run: `cd frontend && npx eslint src/components/ui/ActionErrorCard/ src/components/OAuthButtons/ src/pages/AccountSettingsPage/ src/pages/LoginPage/`
+Expected: エラーなし
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add frontend/src/pages/AccountSettingsPage/useAccountSettings.ts \
+       frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx \
+       frontend/src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx
+git commit -m "feat(frontend): AccountSettingsPage に連携解除失敗時の ActionErrorCard を追加
+
+- last_login_method エラー時に「パスワードを設定する」ボタン付きカード表示
+- ボタンクリックでパスワード設定フォームにスクロール＆フォーカス
+- その他のエラーは従来通りテキスト表示
+
+closes #114"
+```

--- a/docs/superpowers/specs/2026-04-11-auth-error-action-cards-design.md
+++ b/docs/superpowers/specs/2026-04-11-auth-error-action-cards-design.md
@@ -1,0 +1,113 @@
+# 認証エラー時のアクション誘導カード設計
+
+## 概要
+
+OAuthButtons と AccountSettingsPage でエラーが発生した際に、ユーザーが次に取るべきアクションを明示するカード型UIを追加する。
+
+対象Issue: #113, #114
+
+## 背景
+
+- OAuthButtons: エラーメッセージのテキストだけ表示されており、次のアクションが分からない
+- AccountSettingsPage: 連携解除失敗時に「パスワードを設定してください」と出るが、パスワードフォームへの導線がない
+
+## 新規コンポーネント: ActionErrorCard
+
+`frontend/src/components/ui/ActionErrorCard/` に配置する共通コンポーネント。
+
+### Props
+
+```typescript
+type ActionErrorCardProps = {
+  title: string           // 太字のタイトル
+  message: string         // 説明文
+  actionLabel?: string    // ボタンテキスト（省略時はボタン非表示）
+  onAction?: () => void   // ボタンクリック時の処理（省略可）
+}
+```
+
+### デザイン
+
+PR #119 のヒントカードと同じ雰囲気のカード型表示。
+
+- 背景色: `var(--color-error-bg)` (#fef2f2)
+- ボーダー: `var(--color-error)` (#c0392b)
+- 角丸: `var(--radius-md)` (8px)
+- パディング: `var(--spacing-md)` (1rem)
+- タイトル: `var(--color-error)`, `var(--font-weight-medium)`, `var(--font-size-label)`
+- メッセージ: `var(--color-text)`, `var(--font-size-meta)`
+- ボタン: 背景 `var(--color-text)`, 文字 `var(--color-bg-white)`, 角丸 `var(--radius-sm)`
+
+## 変更箇所
+
+### 1. OAuthButtons (#113)
+
+**ファイル:** `frontend/src/components/OAuthButtons/OAuthButtons.tsx`
+
+**現状:** catchブロックで `ApiError.message` のみ使用。エラーコード(`code`)を見ていない。
+
+**変更内容:**
+
+- `error` state を文字列から `{ message: string; code?: string }` 型に変更
+- catchブロックで `ApiError.code` も保持
+- エラーコード別の表示分岐:
+
+| エラーコード | タイトル | ボタン | ボタン動作 |
+|-------------|---------|--------|-----------|
+| `email_already_registered` | ログイン方法が異なります | メールでログイン | メールフォームにスクロール＆フォーカス |
+| `email_registered_with_other_provider` | 別のアカウントで登録済みです | なし | — |
+| その他 | — | — | 現状通りテキスト表示 |
+
+**スクロール先:** LoginPage のメールフォームに `id="email-login-form"` を付与。OAuthButtons は `onAction` コールバック経由でスクロールを実行（親コンポーネントから制御）。
+
+### 2. AccountSettingsPage (#114)
+
+**ファイル:**
+- `frontend/src/pages/AccountSettingsPage/useAccountSettings.ts`
+- `frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx`
+
+**現状:** `providerError` が文字列のみ。エラーコードを保持していない。
+
+**変更内容:**
+
+- `useAccountSettings` フックの `providerError` を `{ message: string; code?: string } | null` 型に変更
+- `last_login_method` エラー時に ActionErrorCard を表示:
+
+| エラーコード | タイトル | ボタン | ボタン動作 |
+|-------------|---------|--------|-----------|
+| `last_login_method` | 解除できません | パスワードを設定する | パスワードフォームにスクロール＆フォーカス |
+| その他 | — | — | 現状通りテキスト表示 |
+
+**スクロール先:** パスワード設定フォームに `id="password-form"` を付与。`scrollIntoView({ behavior: 'smooth' })` でスムーズスクロール。
+
+## バックエンド変更
+
+なし。
+
+- `email_registered_with_other_provider` エラー時のプロバイダ名は `email_conflict_checker.rb` が既にメッセージに埋め込んでいる
+- `last_login_method` エラーは既にコード付きで返却されている
+
+## テスト
+
+### ActionErrorCard 単体テスト
+- タイトルとメッセージが表示される
+- actionLabel を渡した時にボタンが表示される
+- actionLabel を渡さない時にボタンが非表示
+- ボタンクリックで onAction が呼ばれる
+
+### OAuthButtons テスト追加
+- `email_already_registered` エラー時に ActionErrorCard が表示される
+- `email_already_registered` エラー時に「メールでログイン」ボタンが表示される
+- `email_registered_with_other_provider` エラー時に ActionErrorCard が表示される（ボタンなし）
+- その他のエラー時は従来通りテキスト表示
+
+### AccountSettingsPage テスト追加
+- `last_login_method` エラー時に ActionErrorCard が表示される
+- 「パスワードを設定する」ボタンが表示される
+- ボタンクリックでスクロールが実行される
+- その他のエラー時は従来通りテキスト表示
+
+## スタイルルール
+
+- 全てのスタイル値は `tokens.css` のCSS変数を使用
+- ハードコードされた色・サイズ値は禁止

--- a/frontend/src/components/OAuthButtons/OAuthButtons.module.css
+++ b/frontend/src/components/OAuthButtons/OAuthButtons.module.css
@@ -5,6 +5,12 @@
   gap: var(--spacing-sm);
 }
 
+/* 設定ページの providerRow 内に埋め込まれるときは余白を除去してコンパクトにする */
+.containerLink {
+  margin-top: 0;
+  gap: 0;
+}
+
 .divider {
   display: flex;
   align-items: center;

--- a/frontend/src/components/OAuthButtons/OAuthButtons.test.tsx
+++ b/frontend/src/components/OAuthButtons/OAuthButtons.test.tsx
@@ -193,6 +193,61 @@ describe('OAuthButtons', () => {
         expect(screen.getByText(/既にメール\+パスワードで登録/)).toBeInTheDocument()
       })
     })
+
+    it('email_already_registered エラー時に ActionErrorCard が表示される', async () => {
+      const { triggerCallback } = setupGoogleSdkMock()
+      mockSignIn.mockRejectedValue(
+        new ApiError(
+          'このメールアドレスは既にメール+パスワードで登録されています。メールでログインしてください',
+          409,
+          'email_already_registered',
+        ),
+      )
+
+      const mockScrollToEmail = vi.fn()
+      renderWithProviders(<OAuthButtons onScrollToEmailForm={mockScrollToEmail} />)
+      await waitFor(() => expect(window.google).toBeDefined())
+      triggerCallback('dummy-id-token')
+
+      await waitFor(() => {
+        expect(screen.getByText('ログイン方法が異なります')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'メールでログイン' })).toBeInTheDocument()
+      })
+    })
+
+    it('email_registered_with_other_provider エラー時に ActionErrorCard が表示される（ボタンなし）', async () => {
+      const { triggerCallback } = setupGoogleSdkMock()
+      mockSignIn.mockRejectedValue(
+        new ApiError(
+          'このメールアドレスは既にGoogleで登録されています',
+          409,
+          'email_registered_with_other_provider',
+        ),
+      )
+
+      renderWithProviders(<OAuthButtons />)
+      await waitFor(() => expect(window.google).toBeDefined())
+      triggerCallback('dummy-id-token')
+
+      await waitFor(() => {
+        expect(screen.getByText('別のアカウントで登録済みです')).toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'メールでログイン' })).not.toBeInTheDocument()
+      })
+    })
+
+    it('その他のエラーは従来通りテキスト表示', async () => {
+      const { triggerCallback } = setupGoogleSdkMock()
+      mockSignIn.mockRejectedValue(new ApiError('不明なエラー', 500))
+
+      renderWithProviders(<OAuthButtons />)
+      await waitFor(() => expect(window.google).toBeDefined())
+      triggerCallback('dummy-id-token')
+
+      await waitFor(() => {
+        expect(screen.getByText('不明なエラー')).toBeInTheDocument()
+        expect(screen.queryByText('ログイン方法が異なります')).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe('linkモード', () => {

--- a/frontend/src/components/OAuthButtons/OAuthButtons.tsx
+++ b/frontend/src/components/OAuthButtons/OAuthButtons.tsx
@@ -147,7 +147,7 @@ export function OAuthButtons({
   }
 
   return (
-    <div className={styles.container}>
+    <div className={`${styles.container} ${mode === 'link' ? styles.containerLink : ''}`}>
       {mode === 'sign_in' && (
         <div className={styles.divider}>
           <span className={styles.dividerText}>または</span>

--- a/frontend/src/components/OAuthButtons/OAuthButtons.tsx
+++ b/frontend/src/components/OAuthButtons/OAuthButtons.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { ApiError, googleAuthApi } from '../../lib/api'
 import { useAuth } from '../../contexts/useAuth'
+import { ActionErrorCard } from '../ui/ActionErrorCard/ActionErrorCard'
 import type { User } from '../../lib/types'
 import type { GoogleCredentialResponse } from '../../types/google-gsi'
 import styles from './OAuthButtons.module.css'
@@ -17,6 +18,8 @@ type OAuthButtonsProps = {
   mode?: 'sign_in' | 'link'
   onLinkSuccess?: (user: User) => void
   onLinkError?: (message: string) => void
+  // エラー時にメールログインフォームへスクロールするコールバック
+  onScrollToEmailForm?: () => void
 }
 
 // Google Identity Services (ADR-0035) を使ったOAuthボタン。
@@ -28,10 +31,11 @@ export function OAuthButtons({
   mode = 'sign_in',
   onLinkSuccess,
   onLinkError,
+  onScrollToEmailForm,
 }: OAuthButtonsProps = {}) {
   const buttonContainerRef = useRef<HTMLDivElement>(null)
   const [isSdkReady, setIsSdkReady] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const [error, setError] = useState<{ message: string; code?: string } | null>(null)
   const [isProcessing, setIsProcessing] = useState(false)
   const { setUser } = useAuth()
   const navigate = useNavigate()
@@ -52,7 +56,9 @@ export function OAuthButtons({
         setIsSdkReady(true)
         clearInterval(intervalId)
       } else if (elapsed >= GIS_POLL_TIMEOUT_MS) {
-        setError('Googleログインの読み込みに失敗しました。ページを再読み込みしてください')
+        setError({
+          message: 'Googleログインの読み込みに失敗しました。ページを再読み込みしてください',
+        })
         clearInterval(intervalId)
       }
     }, GIS_POLL_INTERVAL_MS)
@@ -66,7 +72,7 @@ export function OAuthButtons({
 
     const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID as string | undefined
     if (!clientId) {
-      setError('Googleログインが設定されていません（VITE_GOOGLE_CLIENT_ID 未定義）')
+      setError({ message: 'Googleログインが設定されていません（VITE_GOOGLE_CLIENT_ID 未定義）' })
       return
     }
 
@@ -106,11 +112,18 @@ export function OAuthButtons({
         await handleSignIn(credential)
       }
     } catch (err) {
-      const message = err instanceof ApiError ? err.message : 'ログインに失敗しました'
-      if (mode === 'link') {
-        onLinkError?.(message)
+      if (err instanceof ApiError) {
+        if (mode === 'link') {
+          onLinkError?.(err.message)
+        } else {
+          setError({ message: err.message, code: err.code })
+        }
       } else {
-        setError(message)
+        if (mode === 'link') {
+          onLinkError?.('ログインに失敗しました')
+        } else {
+          setError({ message: 'ログインに失敗しました' })
+        }
       }
     } finally {
       setIsProcessing(false)
@@ -128,7 +141,7 @@ export function OAuthButtons({
         navigate('/auth/complete', { replace: true })
         break
       case 'error':
-        setError(data.message)
+        setError({ message: data.message, code: data.code })
         break
     }
   }
@@ -147,7 +160,22 @@ export function OAuthButtons({
       />
       {!isSdkReady && !error && <div className={styles.loading}>Googleログインを読み込み中...</div>}
       {isProcessing && <div className={styles.loading}>処理中...</div>}
-      {error && <p className={styles.error}>{error}</p>}
+      {error && error.code === 'email_already_registered' && (
+        <ActionErrorCard
+          title="ログイン方法が異なります"
+          message={error.message}
+          actionLabel="メールでログイン"
+          onAction={onScrollToEmailForm}
+        />
+      )}
+      {error && error.code === 'email_registered_with_other_provider' && (
+        <ActionErrorCard title="別のアカウントで登録済みです" message={error.message} />
+      )}
+      {error &&
+        error.code !== 'email_already_registered' &&
+        error.code !== 'email_registered_with_other_provider' && (
+          <p className={styles.error}>{error.message}</p>
+        )}
     </div>
   )
 }

--- a/frontend/src/components/ui/ActionErrorCard/ActionErrorCard.module.css
+++ b/frontend/src/components/ui/ActionErrorCard/ActionErrorCard.module.css
@@ -1,0 +1,27 @@
+.card {
+  background-color: var(--color-error-bg);
+  border: var(--border-width-thin) var(--border-style) var(--color-error);
+  border-radius: var(--radius-md);
+  padding: var(--spacing-md);
+  margin-top: var(--spacing-sm);
+}
+
+.title {
+  color: var(--color-error);
+  font-family: var(--font-body);
+  font-size: var(--font-size-label);
+  font-weight: var(--font-weight-medium);
+  margin: 0 0 var(--spacing-xs) 0;
+}
+
+.message {
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--font-size-meta);
+  line-height: var(--line-height-normal);
+  margin: 0 0 var(--spacing-sm) 0;
+}
+
+.message:last-child {
+  margin-bottom: 0;
+}

--- a/frontend/src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx
+++ b/frontend/src/components/ui/ActionErrorCard/ActionErrorCard.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi } from 'vitest'
+import { ActionErrorCard } from './ActionErrorCard'
+
+describe('ActionErrorCard', () => {
+  it('タイトルとメッセージが表示される', () => {
+    render(<ActionErrorCard title="エラータイトル" message="エラーの説明文" />)
+
+    expect(screen.getByText('エラータイトル')).toBeInTheDocument()
+    expect(screen.getByText('エラーの説明文')).toBeInTheDocument()
+  })
+
+  it('actionLabelを渡すとボタンが表示される', () => {
+    render(
+      <ActionErrorCard
+        title="タイトル"
+        message="メッセージ"
+        actionLabel="アクションボタン"
+        onAction={() => {}}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'アクションボタン' })).toBeInTheDocument()
+  })
+
+  it('actionLabelを渡さないとボタンが表示されない', () => {
+    render(<ActionErrorCard title="タイトル" message="メッセージ" />)
+
+    expect(screen.queryByRole('button')).not.toBeInTheDocument()
+  })
+
+  it('ボタンクリックでonActionが呼ばれる', async () => {
+    const user = userEvent.setup()
+    const handleAction = vi.fn()
+
+    render(
+      <ActionErrorCard
+        title="タイトル"
+        message="メッセージ"
+        actionLabel="クリック"
+        onAction={handleAction}
+      />,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'クリック' }))
+    expect(handleAction).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/components/ui/ActionErrorCard/ActionErrorCard.tsx
+++ b/frontend/src/components/ui/ActionErrorCard/ActionErrorCard.tsx
@@ -1,0 +1,23 @@
+import { Button } from '../Button/Button'
+import styles from './ActionErrorCard.module.css'
+
+type ActionErrorCardProps = {
+  title: string
+  message: string
+  actionLabel?: string
+  onAction?: () => void
+}
+
+export function ActionErrorCard({ title, message, actionLabel, onAction }: ActionErrorCardProps) {
+  return (
+    <div className={styles.card} role="alert">
+      <p className={styles.title}>{title}</p>
+      <p className={styles.message}>{message}</p>
+      {actionLabel && onAction && (
+        <Button variant="primary" size="sm" onClick={onAction}>
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx
+++ b/frontend/src/pages/AccountSettingsPage/AccountSettingsPage.test.tsx
@@ -1,14 +1,18 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
 import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { AccountSettingsPage } from './AccountSettingsPage'
 import type { User } from '../../lib/types'
 
 // APIモック
+const mockUnlinkProvider = vi.fn()
+const mockSetPassword = vi.fn()
+
 vi.mock('../../lib/api', () => ({
   accountApi: {
-    unlinkProvider: vi.fn(),
-    setPassword: vi.fn(),
+    unlinkProvider: (...args: unknown[]) => mockUnlinkProvider(...args),
+    setPassword: (...args: unknown[]) => mockSetPassword(...args),
   },
   googleAuthApi: {
     signIn: vi.fn(),
@@ -16,10 +20,12 @@ vi.mock('../../lib/api', () => ({
   },
   ApiError: class ApiError extends Error {
     status: number
-    constructor(message: string, status: number) {
+    code?: string
+    constructor(message: string, status: number, code?: string) {
       super(message)
       this.name = 'ApiError'
       this.status = status
+      this.code = code
     }
   },
 }))
@@ -92,6 +98,46 @@ describe('AccountSettingsPage', () => {
     expect(screen.getByText('パスワードを変更')).toBeInTheDocument()
     expect(screen.getByLabelText('新しいパスワード')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '変更する' })).toBeInTheDocument()
+  })
+
+  it('連携解除失敗時（last_login_method）に ActionErrorCard が表示される', async () => {
+    const user = userEvent.setup()
+    mockUser = createUser({ providers: ['google_oauth2'], has_password: true })
+    const { ApiError: MockApiError } = await import('../../lib/api')
+    mockUnlinkProvider.mockRejectedValue(
+      new MockApiError(
+        '最後のログイン手段は解除できません。先にパスワードを設定するか、別のOAuthを連携してください',
+        422,
+        'last_login_method',
+      ),
+    )
+
+    renderPage()
+
+    const unlinkButton = screen.getByRole('button', { name: '解除' })
+    await user.click(unlinkButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('解除できません')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: 'パスワードを設定する' })).toBeInTheDocument()
+    })
+  })
+
+  it('連携解除失敗時（その他エラー）は従来通りテキスト表示', async () => {
+    const user = userEvent.setup()
+    mockUser = createUser({ providers: ['google_oauth2'], has_password: true })
+    const { ApiError: MockApiError } = await import('../../lib/api')
+    mockUnlinkProvider.mockRejectedValue(new MockApiError('サーバーエラー', 500))
+
+    renderPage()
+
+    const unlinkButton = screen.getByRole('button', { name: '解除' })
+    await user.click(unlinkButton)
+
+    await waitFor(() => {
+      expect(screen.getByText('サーバーエラー')).toBeInTheDocument()
+      expect(screen.queryByText('解除できません')).not.toBeInTheDocument()
+    })
   })
 })
 

--- a/frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx
+++ b/frontend/src/pages/AccountSettingsPage/AccountSettingsPage.tsx
@@ -1,5 +1,6 @@
 import { SectionTitle } from '../../components/ui/SectionTitle/SectionTitle'
 import { Button } from '../../components/ui/Button/Button'
+import { ActionErrorCard } from '../../components/ui/ActionErrorCard/ActionErrorCard'
 import { OAuthButtons } from '../../components/OAuthButtons/OAuthButtons'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
 import { useAccountSettings } from './useAccountSettings'
@@ -40,7 +41,24 @@ export function AccountSettingsPage() {
       {/* ログイン方法セクション */}
       <div className={styles.section}>
         <SectionTitle>ログイン方法</SectionTitle>
-        {providerError && <p className={styles.error}>{providerError}</p>}
+        {providerError && providerError.code === 'last_login_method' && (
+          <ActionErrorCard
+            title="解除できません"
+            message={providerError.message}
+            actionLabel="パスワードを設定する"
+            onAction={() => {
+              const form = document.getElementById('password-form')
+              if (form) {
+                form.scrollIntoView({ behavior: 'smooth' })
+                const input = form.querySelector<HTMLInputElement>('input[type="password"]')
+                input?.focus({ preventScroll: true })
+              }
+            }}
+          />
+        )}
+        {providerError && providerError.code !== 'last_login_method' && (
+          <p className={styles.error}>{providerError.message}</p>
+        )}
         <div className={styles.providerList}>
           {/* メール+パスワード */}
           <div className={styles.providerRow}>
@@ -86,7 +104,7 @@ export function AccountSettingsPage() {
                   <OAuthButtons
                     mode="link"
                     onLinkSuccess={(updatedUser) => setUser(updatedUser)}
-                    onLinkError={(message) => setProviderError(message)}
+                    onLinkError={(message) => setProviderError({ message })}
                   />
                 )}
               </div>
@@ -98,7 +116,7 @@ export function AccountSettingsPage() {
       {/* パスワード設定セクション */}
       <div className={styles.section}>
         <SectionTitle>{user.has_password ? 'パスワードを変更' : 'パスワードを設定'}</SectionTitle>
-        <form className={styles.form} onSubmit={handlePasswordSubmit}>
+        <form id="password-form" className={styles.form} onSubmit={handlePasswordSubmit}>
           <FormInput
             label={user.has_password ? '新しいパスワード' : 'パスワード'}
             id="password"

--- a/frontend/src/pages/AccountSettingsPage/useAccountSettings.ts
+++ b/frontend/src/pages/AccountSettingsPage/useAccountSettings.ts
@@ -16,7 +16,10 @@ export function useAccountSettings() {
   const [passwordSuccess, setPasswordSuccess] = useState('')
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [unlinkingProvider, setUnlinkingProvider] = useState<string | null>(null)
-  const [providerError, setProviderError] = useState('')
+  const [providerError, setProviderError] = useState<{
+    message: string
+    code?: string
+  } | null>(null)
 
   const totalMethods = user ? countLoginMethods(user.has_password, user.providers) : 0
 
@@ -24,7 +27,7 @@ export function useAccountSettings() {
   const canUnlink = totalMethods > 1
 
   const handleUnlinkProvider = async (provider: string) => {
-    setProviderError('')
+    setProviderError(null)
     setUnlinkingProvider(provider)
 
     try {
@@ -32,9 +35,9 @@ export function useAccountSettings() {
       setUser(response.user)
     } catch (err) {
       if (err instanceof ApiError) {
-        setProviderError(err.message)
+        setProviderError({ message: err.message, code: err.code })
       } else {
-        setProviderError('連携解除に失敗しました')
+        setProviderError({ message: '連携解除に失敗しました' })
       }
     } finally {
       setUnlinkingProvider(null)

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -67,7 +67,7 @@ export function LoginPage() {
         <Typography variant="h2">ログイン</Typography>
         <Divider />
         {successMessage && <p className={styles.success}>{successMessage}</p>}
-        <form className={styles.form} onSubmit={handleSubmit}>
+        <form id="email-login-form" className={styles.form} onSubmit={handleSubmit}>
           <FormInput
             label="メールアドレス"
             id="email"
@@ -136,7 +136,16 @@ export function LoginPage() {
             {isSubmitting ? 'ログイン中...' : 'ログイン'}
           </Button>
         </form>
-        <OAuthButtons />
+        <OAuthButtons
+          onScrollToEmailForm={() => {
+            const form = document.getElementById('email-login-form')
+            if (form) {
+              form.scrollIntoView({ behavior: 'smooth' })
+              const emailInput = form.querySelector<HTMLInputElement>('input[type="email"]')
+              emailInput?.focus({ preventScroll: true })
+            }
+          }}
+        />
         <div className={styles.link}>
           <Link to="/password/new">パスワードをお忘れですか？</Link>
         </div>


### PR DESCRIPTION
## Summary
- 共通コンポーネント `ActionErrorCard` を新規作成（エラーメッセージ + タイトル + アクションボタンのカード型UI）
- OAuthButtons: エラーコード別に ActionErrorCard を表示（`email_already_registered` → 「メールでログイン」ボタン、`email_registered_with_other_provider` → プロバイダ名明示）
- AccountSettingsPage: 連携解除失敗時（`last_login_method`）に「パスワードを設定する」ボタン付きカード表示
- OAuthButtons link モードの余白を除去してコンパクトに

## Related Issues
closes #113, closes #114

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `components/ui/ActionErrorCard/` | 新規: 共通エラーカードコンポーネント + テスト + CSS |
| `components/OAuthButtons/OAuthButtons.tsx` | error state を `{ message, code }` 型に拡張、エラーコード別分岐 |
| `components/OAuthButtons/OAuthButtons.module.css` | link モード用コンパクトスタイル追加 |
| `pages/LoginPage/LoginPage.tsx` | フォームに `id` 付与、スクロールコールバック追加 |
| `pages/AccountSettingsPage/useAccountSettings.ts` | providerError を `{ message, code }` 型に拡張 |
| `pages/AccountSettingsPage/AccountSettingsPage.tsx` | ActionErrorCard 組み込み、パスワードフォームに `id` 付与 |

## Test plan
- [x] ActionErrorCard 単体テスト 4件パス
- [x] OAuthButtons テスト 11件パス（新規3件追加）
- [x] AccountSettingsPage テスト 6件パス（新規2件追加）
- [x] 全フロントエンドテスト 449件パス（回帰なし）
- [x] ESLint / Prettier エラーなし
- [x] Playwright MCP で LoginPage / AccountSettingsPage の構造・表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)