### PR TITLE
fix: 検索品質改善 - 補完強化・品質ソート・キャンセル・シリーズ流用 #127

### DIFF
--- a/backend/app/services/external_apis/google_books_adapter.rb
+++ b/backend/app/services/external_apis/google_books_adapter.rb
@@ -40,10 +40,20 @@ module ExternalApis
           published_date: info['publishedDate'],
           page_count: info['pageCount'],
           categories: info['categories'],
+          # ISBNはopenBD補完に使用する。ISBN-13を優先し、なければISBN-10
+          isbn: extract_isbn(info),
           # ratingsCountで人気度を推定。100件レビューで正規化上限1.0
           popularity: normalize_popularity(info['ratingsCount'])
         }.compact
       )
+    end
+
+    # industryIdentifiersからISBNを抽出。ISBN-13を最優先、なければISBN-10
+    def extract_isbn(info)
+      identifiers = info['industryIdentifiers'] || []
+      isbn13 = identifiers.find { |i| i['type'] == 'ISBN_13' }
+      isbn10 = identifiers.find { |i| i['type'] == 'ISBN_10' }
+      isbn13&.dig('identifier') || isbn10&.dig('identifier')
     end
 
     # Google Booksのレビュー数を0.0〜1.0に正規化

--- a/backend/app/services/external_apis/openbd_client.rb
+++ b/backend/app/services/external_apis/openbd_client.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module ExternalApis
+  # openBDから書誌データを取得するクライアント
+  # https://openbd.jp/
+  # APIキー不要・無料・ISBNベースで書誌情報と書影を提供する日本書籍データベース
+  # WorkSearchService#enrich_books_via_openbd から使用される
+  class OpenbdClient
+    BASE_URL = 'https://api.openbd.jp'
+    ENDPOINT_PATH = '/v1/get'
+    USER_AGENT = 'Recolly/1.0 (https://github.com/IKcoding-jp/Recolly)'
+
+    # ISBN から書誌データを取得する
+    # 戻り値: { cover_image_url: String|nil, description: String|nil } または nil
+    def fetch(isbn)
+      return nil if isbn.blank?
+
+      response = connection.get(ENDPOINT_PATH, { isbn: isbn })
+      data = response.body&.first
+      return nil if data.nil?
+
+      {
+        cover_image_url: extract_cover_url(data),
+        description: extract_description(data)
+      }
+    rescue Faraday::Error => e
+      Rails.logger.error("[OpenbdClient] 取得エラー: #{e.message}")
+      nil
+    end
+
+    private
+
+    # openBDレスポンス構造: summary.cover に画像URL（文字列）
+    def extract_cover_url(data)
+      data.dig('summary', 'cover').presence
+    end
+
+    # openBDレスポンス構造: onix.CollateralDetail.TextContent は配列
+    # TextType='03' は内容紹介（書籍紹介文）を意味する
+    def extract_description(data)
+      text_contents = data.dig('onix', 'CollateralDetail', 'TextContent') || []
+      intro = text_contents.find { |t| t['TextType'] == '03' }
+      intro&.dig('Text').presence
+    end
+
+    def connection
+      @connection ||= Faraday.new(
+        url: BASE_URL, request: { open_timeout: 5, timeout: 10 }
+      ) do |f|
+        f.response :json
+        f.headers['User-Agent'] = USER_AGENT
+        f.adapter Faraday.default_adapter
+      end
+    end
+  end
+end

--- a/backend/app/services/external_apis/openbd_client.rb
+++ b/backend/app/services/external_apis/openbd_client.rb
@@ -6,6 +6,8 @@ module ExternalApis
   # APIキー不要・無料・ISBNベースで書誌情報と書影を提供する日本書籍データベース
   # WorkSearchService#enrich_books_via_openbd から使用される
   class OpenbdClient
+    # NOTE: Faradayは '/' 始まりのパスを渡されるとbase_urlのパス部を破棄する仕様。
+    # そのため BASE_URL にはホストのみを指定し、パスは ENDPOINT_PATH 側で持つ
     BASE_URL = 'https://api.openbd.jp'
     ENDPOINT_PATH = '/v1/get'
     USER_AGENT = 'Recolly/1.0 (https://github.com/IKcoding-jp/Recolly)'

--- a/backend/app/services/external_apis/title_matcher.rb
+++ b/backend/app/services/external_apis/title_matcher.rb
@@ -10,40 +10,44 @@ module ExternalApis
   # 同じ親作品の説明が付与されてしまう regression が起きる。
   # この検証をクライアント側に挟み、明らかに別作品とみなせる場合は弾く。
   module TitleMatcher
-    # 親/子作品とみなす長さの倍率閾値
-    # この倍率以上の長さの差があり、長い方が短い方を含む場合は別作品扱いで却下する
-    PARENT_CHILD_LENGTH_RATIO = 1.5
-
     module_function
 
     # クエリと結果のタイトルが「同じ作品」と判断できるかチェックする
-    # 1. NFKC 正規化 + 小文字化 + 空白除去で軽微な表記揺れを吸収
-    # 2. 完全一致なら true
-    # 3. 一方が他方の1.5倍以上長く、長い方が短い方を含む場合は親/子作品とみなして却下
-    #    例: '進撃の巨人 Season 2' (12) vs '進撃の巨人' (5) → 1.5倍以上 + 含む → false
-    # 4. それ以外で部分一致するなら採用（軽微な表記揺れの吸収）
+    # NFKC 正規化 + 小文字化 + 空白除去で軽微な表記揺れを吸収した上で、
+    # 完全一致のみを採用する。
+    #
+    # 部分一致 fallback や「1.5倍以上の長さ差」ルールは過去に試したが、
+    # '呪術廻戦 0' vs '呪術廻戦' や 'FFX' vs 'FF' のような短いナンバリングタイトルで
+    # 誤マッチが起きるため廃止した。表記揺れは normalize_for_match で吸収する方針。
     def title_match?(query, candidate)
-      return false if query.blank? || candidate.blank?
+      return false if blank_or_invalid?(query) || blank_or_invalid?(candidate)
 
       q = normalize_for_match(query)
       c = normalize_for_match(candidate)
-      return true if q == c
-      return false if parent_child_mismatch?(q, c)
+      return false if q.empty? || c.empty?
 
-      q.include?(c) || c.include?(q)
+      q == c
     end
 
     # 全角/半角、大小文字、空白の表記揺れを吸収する
     # NFKC 正規化で全角英数字・記号は半角化され、全角空白も半角空白になる
+    #
+    # 外部 API から不正な UTF-8 バイト列が返ってきた場合に
+    # unicode_normalize が ArgumentError を投げると検索全体が落ちるため、
+    # 防御的に rescue して空文字を返す（title_match? で false 扱いになる）。
     def normalize_for_match(text)
       text.unicode_normalize(:nfkc).downcase.gsub(/\s+/, '')
+    rescue ArgumentError, Encoding::UndefinedConversionError
+      ''
     end
 
-    # 一方が他方の PARENT_CHILD_LENGTH_RATIO 倍以上長く、長い方が短い方を含むか判定する
-    # 真なら「親作品 vs 子作品（シーズン/OVA/外伝等）」とみなして却下対象になる
-    def parent_child_mismatch?(left, right)
-      (left.length > right.length * PARENT_CHILD_LENGTH_RATIO && left.include?(right)) ||
-        (right.length > left.length * PARENT_CHILD_LENGTH_RATIO && right.include?(left))
+    # nil / 空文字 / 空白だけの文字列 / 不正な UTF-8 バイト列を含む文字列を弾く
+    # ActiveSupport の blank? は内部で strip を呼ぶため、不正な UTF-8 でも
+    # ArgumentError が発生する。それを安全に false（=「使えない」）扱いする。
+    def blank_or_invalid?(text)
+      text.blank?
+    rescue ArgumentError, Encoding::UndefinedConversionError
+      true
     end
   end
 end

--- a/backend/app/services/external_apis/title_matcher.rb
+++ b/backend/app/services/external_apis/title_matcher.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module ExternalApis
+  # 検索クエリと外部APIから返ってきた候補タイトルが「同じ作品」と判断できるか検証するモジュール
+  #
+  # 背景:
+  # TMDB や Wikipedia の検索 API は曖昧マッチで、'進撃の巨人 Season 2' のような
+  # シリーズ識別子付きクエリで親作品 '進撃の巨人' を返してしまうことがある。
+  # その親作品の説明を補完に採用すると、シーズン違い・OVA・外伝など全く別の作品にも
+  # 同じ親作品の説明が付与されてしまう regression が起きる。
+  # この検証をクライアント側に挟み、明らかに別作品とみなせる場合は弾く。
+  module TitleMatcher
+    # 親/子作品とみなす長さの倍率閾値
+    # この倍率以上の長さの差があり、長い方が短い方を含む場合は別作品扱いで却下する
+    PARENT_CHILD_LENGTH_RATIO = 1.5
+
+    module_function
+
+    # クエリと結果のタイトルが「同じ作品」と判断できるかチェックする
+    # 1. NFKC 正規化 + 小文字化 + 空白除去で軽微な表記揺れを吸収
+    # 2. 完全一致なら true
+    # 3. 一方が他方の1.5倍以上長く、長い方が短い方を含む場合は親/子作品とみなして却下
+    #    例: '進撃の巨人 Season 2' (12) vs '進撃の巨人' (5) → 1.5倍以上 + 含む → false
+    # 4. それ以外で部分一致するなら採用（軽微な表記揺れの吸収）
+    def title_match?(query, candidate)
+      return false if query.blank? || candidate.blank?
+
+      q = normalize_for_match(query)
+      c = normalize_for_match(candidate)
+      return true if q == c
+      return false if parent_child_mismatch?(q, c)
+
+      q.include?(c) || c.include?(q)
+    end
+
+    # 全角/半角、大小文字、空白の表記揺れを吸収する
+    # NFKC 正規化で全角英数字・記号は半角化され、全角空白も半角空白になる
+    def normalize_for_match(text)
+      text.unicode_normalize(:nfkc).downcase.gsub(/\s+/, '')
+    end
+
+    # 一方が他方の PARENT_CHILD_LENGTH_RATIO 倍以上長く、長い方が短い方を含むか判定する
+    # 真なら「親作品 vs 子作品（シーズン/OVA/外伝等）」とみなして却下対象になる
+    def parent_child_mismatch?(left, right)
+      (left.length > right.length * PARENT_CHILD_LENGTH_RATIO && left.include?(right)) ||
+        (right.length > left.length * PARENT_CHILD_LENGTH_RATIO && right.include?(left))
+    end
+  end
+end

--- a/backend/app/services/external_apis/tmdb_adapter.rb
+++ b/backend/app/services/external_apis/tmdb_adapter.rb
@@ -25,6 +25,7 @@ module ExternalApis
 
     # AniListの結果に対して、TMDBから日本語の説明文を取得する
     # タイトルでTMDBを検索し、最初にマッチしたmovie/tvの日本語overviewを返す
+    # ただし TMDB が曖昧マッチで親作品（Season 1 等）を返すケースは TitleMatcher で弾く
     # 見つからない場合やエラー時はnilを返す（呼び出し元で英語説明をフォールバックに使う）
     def fetch_japanese_description(query)
       response = tmdb_connection.get('/3/search/multi',
@@ -33,7 +34,7 @@ module ExternalApis
                                      language: 'ja')
 
       results = response.body['results'] || []
-      best_match_overview(results)
+      best_match_description(results, query)
     rescue Faraday::Error => e
       Rails.logger.error("[TmdbAdapter] 日本語説明取得エラー: #{e.message}")
       nil
@@ -73,13 +74,23 @@ module ExternalApis
       combined
     end
 
-    # 日本のアニメーション作品を判定（AniListで取得するため、TMDBからは除外する）
-    # genre_ids に Animation(16) が含まれ、かつ原語が日本語の場合はアニメとみなす
-    # 日本語原語の作品を優先してoverviewを返す（同名の外国作品との誤マッチを防止）
-    def best_match_overview(results)
+    # 候補から最も適切な日本語説明を選ぶ
+    # 1. movie/tv のみ対象
+    # 2. 日本語原語を優先（同名の外国作品との誤マッチを防止）
+    # 3. 選択した結果の name/title が query と十分一致しない場合は nil
+    #    （TMDB が 'X Season 2' で親作品 'X' を返す誤マッチ防止）
+    # 注: title_match? は「絞り込み後の match に対してのみ」呼ぶこと。
+    # 先に title_match? でフィルタすると日本語原語優先の挙動が崩れるため。
+    def best_match_description(results, query)
       candidates = results.select { |item| %w[movie tv].include?(item['media_type']) }
       match = candidates.find { |item| item['original_language'] == 'ja' } || candidates.first
-      match&.dig('overview').presence
+      return nil unless match
+
+      # tv は name、movie は title を使う
+      match_title = match['name'] || match['title']
+      return nil unless TitleMatcher.title_match?(query, match_title)
+
+      match['overview'].presence
     end
 
     # search/movie エンドポイントで映画を検索

--- a/backend/app/services/external_apis/wikipedia_client.rb
+++ b/backend/app/services/external_apis/wikipedia_client.rb
@@ -32,15 +32,19 @@ module ExternalApis
     end
 
     # 検索APIで記事タイトルを探し、見つかった最上位記事の概要を返す
-    # 完全一致を要求する fetch_extract と違い、タイトルの表記揺れや副題付きでもマッチする
-    # 例: "呪術廻戦 第2期" で検索 → "呪術廻戦" 記事の概要を返す
+    # 完全一致を要求する fetch_extract と違い、タイトルの軽微な表記揺れを許容する
+    # ただしシリーズもの（Season X、OVA 等）の検索で親記事にマッチしてしまうケースは
+    # TitleMatcher で弾き、誤った親作品の説明を補完に使ってしまうのを防ぐ
     def search_and_fetch_extract(query)
       return nil if query.blank?
 
       titles = search(query, limit: 1)
       return nil if titles.empty?
 
-      fetch_extract(titles.first)
+      found_title = titles.first
+      return nil unless TitleMatcher.title_match?(query, found_title)
+
+      fetch_extract(found_title)
     end
 
     # 日本語Wikipediaの言語間リンクから英語タイトルを取得する

--- a/backend/app/services/external_apis/wikipedia_client.rb
+++ b/backend/app/services/external_apis/wikipedia_client.rb
@@ -31,6 +31,18 @@ module ExternalApis
       nil
     end
 
+    # 検索APIで記事タイトルを探し、見つかった最上位記事の概要を返す
+    # 完全一致を要求する fetch_extract と違い、タイトルの表記揺れや副題付きでもマッチする
+    # 例: "呪術廻戦 第2期" で検索 → "呪術廻戦" 記事の概要を返す
+    def search_and_fetch_extract(query)
+      return nil if query.blank?
+
+      titles = search(query, limit: 1)
+      return nil if titles.empty?
+
+      fetch_extract(titles.first)
+    end
+
     # 日本語Wikipediaの言語間リンクから英語タイトルを取得する
     def fetch_english_title(title)
       response = connection.get('', langlink_params(title))

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -6,13 +6,9 @@
 class WorkSearchService # rubocop:disable Metrics/ClassLength
   CACHE_TTL = 12.hours
   # 実装変更時にインクリメントしてキャッシュを無効化する
-  CACHE_VERSION = 'v3'
+  # v4: シリーズ親説明流用の境界文字判定を追加（normalize 空白保持 + ratio 廃止）
+  CACHE_VERSION = 'v4'
   ENRICHMENT_BATCH_SIZE = 5
-
-  # 親プレフィックスマッチで親が子の何倍以下の長さなら採用するかの閾値
-  # 0.8 = 親が子の長さの80%以下
-  # "進撃の巨人"(5) と "進撃の巨人ファン"(8) のような誤マッチを軽減する
-  PARENT_PREFIX_RATIO = 0.8
 
   def search(query, media_type: nil)
     cache_key = "work_search:#{CACHE_VERSION}:#{media_type || 'all'}:#{query}"
@@ -205,7 +201,8 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
 
   # 結果に対して、プレフィックスとしてマッチする親候補を探す
   # - 親の正規化タイトルが子の正規化タイトルの先頭部分と完全一致する
-  # - 親が子よりも十分短い（親の長さが子の 80% 以下）
+  # - 親プレフィックスの直後が「文字/数字」でないこと（境界文字判定）
+  #   → "進撃の巨人ファンクラブ" や "FATEstay" のような同単語の続きを別作品として除外する
   # - 正規表現で series 識別子を列挙するよりも汎用的で、
   #   "進撃の巨人 Season 2", "Re:ゼロ 2nd Season", "HUNTER×HUNTER (2011)",
   #   "HUNTER×HUNTER: Greed Island", "シュタインズ・ゲート ゼロ" 等を包括的に検出できる
@@ -219,21 +216,34 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
   end
 
   # 親候補が対象結果のプレフィックス親として成立するか判定する
+  # 境界文字判定: 親プレフィックスの直後の1文字が letter (\p{L}) または number (\p{N}) なら、
+  # 同じ単語の続きと見なし別作品として除外する。
+  # OK 例: "進撃の巨人 Season 2"（直後が空白）、"HUNTER×HUNTER: Greed Island"（直後が記号）
+  # NG 例: "進撃の巨人ファンクラブ"（直後が "フ" = L）、"FATEstay"（直後が "s" = L）
   def valid_prefix_parent?(parent, result, child_norm)
     return false if parent.equal?(result) # 自分自身は除外
 
     parent_norm = normalize_for_parent_match(parent.title)
-    return false if parent_norm.blank?
-    return false if parent_norm == child_norm # 同名の重複は親子関係ではない
-    return false unless child_norm.start_with?(parent_norm)
+    return false unless prefix_parent_structure_ok?(parent_norm, child_norm)
 
-    # 親が子よりも十分短いことを確認（誤マッチ軽減のための閾値）
-    parent_norm.length <= child_norm.length * PARENT_PREFIX_RATIO
+    boundary_char = child_norm[parent_norm.length]
+    !boundary_char&.match?(/[\p{L}\p{N}]/)
   end
 
-  # 親マッチ用の表記揺れ吸収（NFKC + 大小文字 + 空白除去）
+  # プレフィックスマッチの構造的条件（親が空でなく、子と同名でなく、子の真のプレフィックスである）
+  def prefix_parent_structure_ok?(parent_norm, child_norm)
+    return false if parent_norm.blank?
+    return false if parent_norm == child_norm
+    return false unless child_norm.start_with?(parent_norm)
+
+    child_norm.length > parent_norm.length
+  end
+
+  # 親マッチ用の表記揺れ吸収（NFKC 正規化 + 小文字化）
+  # 空白は「親プレフィックスの境界判定」で必要になるため削除せず単一の半角空白に統一する。
+  # 連続する空白や全角空白は NFKC + gsub で1個の半角空白に潰す。
   def normalize_for_parent_match(text)
-    text.unicode_normalize(:nfkc).downcase.gsub(/\s+/, '')
+    text.unicode_normalize(:nfkc).downcase.strip.gsub(/\s+/, ' ')
   end
 
   # 品質スコア（0.0〜1.0）: 画像あり=0.5, 説明あり=0.5

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -15,8 +15,7 @@ class WorkSearchService
       results = results.select { |r| r.media_type == media_type } if media_type.present?
 
       enrich_books_via_openbd(results)
-      enrich_anilist_descriptions(results)
-      remove_english_descriptions(results)
+      enrich_missing_descriptions(results)
       sort_by_popularity(results)
     end
   end
@@ -99,33 +98,37 @@ class WorkSearchService
     result.description ||= data[:description]
   end
 
-  # AniListの結果にTMDB→Wikipediaの順で日本語説明を補完する
-  # AniListの説明は英語のため、日本語の説明が見つかれば置き換える
+  # 説明が空 or 英語の全結果を対象に日本語説明を補完する
+  # 以前は AniList 結果のみが対象だったが、IGDB（ゲーム）・Google Books（本）・TMDB（映画/ドラマ）にも拡張
   # 外部APIへの同時接続数を制限するため、5件ずつのバッチで並列処理する
-  def enrich_anilist_descriptions(results)
-    anilist_results = results.select { |r| r.external_api_source == 'anilist' }
-    return if anilist_results.empty?
+  def enrich_missing_descriptions(results)
+    needs_enrichment = results.select do |r|
+      r.description.blank? || english_text?(r.description)
+    end
+    return if needs_enrichment.empty?
 
-    anilist_results.each_slice(ENRICHMENT_BATCH_SIZE) do |batch|
+    needs_enrichment.each_slice(ENRICHMENT_BATCH_SIZE) do |batch|
       threads = batch.map do |result|
-        Thread.new { enrich_single_description(result) }
+        Thread.new { try_enrich_description(result) }
       end
       threads.each(&:join)
     end
   end
 
-  # スレッドごとに独立したアダプターインスタンスを使用する
-  # （Faradayコネクションの共有を避けるため）
-  def enrich_single_description(result)
+  # 補完の試行順:
+  # 1. TMDB日本語説明（映画・ドラマは元々これで取れる。AniList結果は title_english/title_romaji も試す）
+  # 2. Wikipedia search_and_fetch_extract（完全一致制約を回避した検索→取得の2段階）
+  # 3. 元の説明にフォールバック（英語でも nil にせずそのまま残す）
+  def try_enrich_description(result)
     tmdb = ExternalApis::TmdbAdapter.new
     wikipedia = ExternalApis::WikipediaClient.new
+
     description = fetch_japanese_description_from_tmdb(result, tmdb)
-    description ||= wikipedia.fetch_extract(result.title)
+    description ||= wikipedia.search_and_fetch_extract(result.title)
     result.description = resolve_description(description, result.description)
   end
 
-  # TMDBで日本語説明を検索（日本語タイトル優先で複数パターンを順番に試す）
-  # 日本語タイトルの方がTMDB（language: 'ja'）でのマッチ精度が高い
+  # TMDBで日本語説明を検索（メタデータにtitle_english/title_romajiがあれば順番に試す）
   def fetch_japanese_description_from_tmdb(result, tmdb)
     queries = [
       result.title,
@@ -140,19 +143,15 @@ class WorkSearchService
     nil
   end
 
-  # 全結果から英語の説明文を除去する（IGDB等の英語説明も対象）
-  def remove_english_descriptions(results)
-    results.each { |r| r.description = nil if english_text?(r.description) }
-  end
-
-  # 日本語説明が見つかればそれを使い、見つからなければ英語説明を除去する
+  # 日本語説明が見つかればそれを使う。見つからなくても元の説明を消さない（英語でも残す）
+  # 以前の remove_english_descriptions は「英語なら nil 化」という破壊的動作だったため廃止
   def resolve_description(japanese_desc, original_desc)
     return japanese_desc if japanese_desc.present?
 
-    english_text?(original_desc) ? nil : original_desc
+    original_desc
   end
 
-  # 文字列の半分以上がASCII文字なら英語と判定
+  # 文字列の半分以上がASCII文字なら英語と判定（補完対象の選定に使用）
   def english_text?(text)
     return false if text.blank?
 

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -71,10 +71,9 @@ class WorkSearchService
     book_results = results.select { |r| openbd_enrichment_target?(r) }
     return if book_results.empty?
 
-    openbd = ExternalApis::OpenbdClient.new
     book_results.each_slice(ENRICHMENT_BATCH_SIZE) do |batch|
       threads = batch.map do |result|
-        Thread.new { enrich_single_book(result, openbd) }
+        Thread.new { enrich_single_book(result) }
       end
       threads.each(&:join)
     end
@@ -88,8 +87,11 @@ class WorkSearchService
     result.metadata[:isbn].present?
   end
 
+  # スレッドごとに独立したクライアントインスタンスを使用する
+  # （Faradayコネクションの共有を避けるため、AniList補完と同じ方針）
   # 欠損している項目だけを補完する（既存データは上書きしない）
-  def enrich_single_book(result, openbd)
+  def enrich_single_book(result)
+    openbd = ExternalApis::OpenbdClient.new
     data = openbd.fetch(result.metadata[:isbn])
     return if data.nil?
 

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -13,6 +13,8 @@ class WorkSearchService
       adapters = select_adapters(media_type)
       results = fetch_from_adapters_in_parallel(adapters, query, media_type)
       results = results.select { |r| r.media_type == media_type } if media_type.present?
+
+      enrich_books_via_openbd(results)
       enrich_anilist_descriptions(results)
       remove_english_descriptions(results)
       sort_by_popularity(results)
@@ -61,6 +63,38 @@ class WorkSearchService
       ExternalApis::GoogleBooksAdapter.new,
       ExternalApis::IgdbAdapter.new
     ]
+  end
+
+  # Google Booksの結果のうち画像・説明が欠損しているものを openBD で補完する
+  # ISBN が metadata にない結果はスキップする（openBDはISBNベース）
+  def enrich_books_via_openbd(results)
+    book_results = results.select { |r| openbd_enrichment_target?(r) }
+    return if book_results.empty?
+
+    openbd = ExternalApis::OpenbdClient.new
+    book_results.each_slice(ENRICHMENT_BATCH_SIZE) do |batch|
+      threads = batch.map do |result|
+        Thread.new { enrich_single_book(result, openbd) }
+      end
+      threads.each(&:join)
+    end
+  end
+
+  # openBD 補完対象の判定（google_books由来で画像か説明が欠損しISBNを持つ）
+  def openbd_enrichment_target?(result)
+    return false unless result.external_api_source == 'google_books'
+    return false unless result.cover_image_url.blank? || result.description.blank?
+
+    result.metadata[:isbn].present?
+  end
+
+  # 欠損している項目だけを補完する（既存データは上書きしない）
+  def enrich_single_book(result, openbd)
+    data = openbd.fetch(result.metadata[:isbn])
+    return if data.nil?
+
+    result.cover_image_url ||= data[:cover_image_url]
+    result.description ||= data[:description]
   end
 
   # AniListの結果にTMDB→Wikipediaの順で日本語説明を補完する

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -9,13 +9,10 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
   CACHE_VERSION = 'v3'
   ENRICHMENT_BATCH_SIZE = 5
 
-  # シリーズもの（Season N, OVA, 完結編, 第N期 等）を検出する正規表現
-  # "進撃の巨人 Season 2" → ["進撃の巨人", "Season 2"]
-  # "進撃の巨人 完結編 前編" → ["進撃の巨人", "完結編 前編"]
-  # 親タイトル（最短マッチ）+ 半角/全角スペース + シリーズ識別子 の構造で検出する
-  # rubocop:disable Layout/LineLength
-  SERIES_PATTERN = /\A(.+?)[\s　]+(Season[\s　]*[\d０-９]+.*|Part[\s　]*[\d０-９]+.*|OVA.*|Special.*|The[\s　]*Final[\s　]*Season.*|Final[\s　]*Season.*|完結編.*|外伝.*|第[\d０-９]+期.*|シーズン[\s　]*[\d０-９]+.*|劇場版.*)\z/i
-  # rubocop:enable Layout/LineLength
+  # 親プレフィックスマッチで親が子の何倍以下の長さなら採用するかの閾値
+  # 0.8 = 親が子の長さの80%以下
+  # "進撃の巨人"(5) と "進撃の巨人ファン"(8) のような誤マッチを軽減する
+  PARENT_PREFIX_RATIO = 0.8
 
   def search(query, media_type: nil)
     cache_key = "work_search:#{CACHE_VERSION}:#{media_type || 'all'}:#{query}"
@@ -177,13 +174,13 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
   # 流用した結果には metadata[:description_from_parent] = true を付与し、
   # フロント側で「※シリーズ全体の説明」と注釈表示する
   def share_series_descriptions(results)
-    parents = build_parent_map(results)
+    parents = build_parent_candidates(results)
     return if parents.empty?
 
     results.each do |result|
       next unless needs_parent_description?(result)
 
-      parent = find_matching_parent(result, parents)
+      parent = find_parent_by_prefix(result, parents)
       next unless parent
 
       result.description = parent.description
@@ -191,14 +188,12 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
     end
   end
 
-  # 親候補の正規化タイトル → 親 result のマップを構築する
-  # 親候補の条件: シリーズ識別子を含まず、日本語説明を持っている
-  def build_parent_map(results)
-    results.each_with_object({}) do |r, map|
-      next if series_subitem?(r.title)
-      next if r.description.blank? || english_text?(r.description)
-
-      map[normalize_for_parent_match(r.title)] = r
+  # 親候補リストを構築する
+  # 親の条件: 日本語説明を持っていること
+  # （シリーズ識別子の有無は判定しない。プレフィックスマッチで子を検出する）
+  def build_parent_candidates(results)
+    results.select do |r|
+      r.description.present? && !english_text?(r.description)
     end
   end
 
@@ -208,21 +203,32 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
     result.description.blank? || english_text?(result.description)
   end
 
-  # 結果のタイトルからシリーズ親を探す
-  # "進撃の巨人 Season 2" → 親候補 "進撃の巨人" → parents マップから取得
-  def find_matching_parent(result, parents)
-    match = SERIES_PATTERN.match(result.title)
-    return nil unless match
+  # 結果に対して、プレフィックスとしてマッチする親候補を探す
+  # - 親の正規化タイトルが子の正規化タイトルの先頭部分と完全一致する
+  # - 親が子よりも十分短い（親の長さが子の 80% 以下）
+  # - 正規表現で series 識別子を列挙するよりも汎用的で、
+  #   "進撃の巨人 Season 2", "Re:ゼロ 2nd Season", "HUNTER×HUNTER (2011)",
+  #   "HUNTER×HUNTER: Greed Island", "シュタインズ・ゲート ゼロ" 等を包括的に検出できる
+  # 複数の親候補がマッチする場合はより詳細（長い）な親を優先する
+  def find_parent_by_prefix(result, parents)
+    child_norm = normalize_for_parent_match(result.title)
+    return nil if child_norm.blank?
 
-    parent_title = match[1].to_s.strip
-    return nil if parent_title.blank?
-
-    parents[normalize_for_parent_match(parent_title)]
+    matched = parents.select { |parent| valid_prefix_parent?(parent, result, child_norm) }
+    matched.max_by { |parent| normalize_for_parent_match(parent.title).length }
   end
 
-  # シリーズ識別子（Season N, OVA, 完結編 等）を持つ作品か判定
-  def series_subitem?(title)
-    SERIES_PATTERN.match?(title)
+  # 親候補が対象結果のプレフィックス親として成立するか判定する
+  def valid_prefix_parent?(parent, result, child_norm)
+    return false if parent.equal?(result) # 自分自身は除外
+
+    parent_norm = normalize_for_parent_match(parent.title)
+    return false if parent_norm.blank?
+    return false if parent_norm == child_norm # 同名の重複は親子関係ではない
+    return false unless child_norm.start_with?(parent_norm)
+
+    # 親が子よりも十分短いことを確認（誤マッチ軽減のための閾値）
+    parent_norm.length <= child_norm.length * PARENT_PREFIX_RATIO
   end
 
   # 親マッチ用の表記揺れ吸収（NFKC + 大小文字 + 空白除去）

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -16,7 +16,7 @@ class WorkSearchService
 
       enrich_books_via_openbd(results)
       enrich_missing_descriptions(results)
-      sort_by_popularity(results)
+      sort_by_quality_and_popularity(results)
     end
   end
 
@@ -159,8 +159,20 @@ class WorkSearchService
     ascii_ratio > 0.5
   end
 
-  # 各アダプターが返すmetadata[:popularity]（0.0〜1.0に正規化済み）で降順ソート
-  def sort_by_popularity(results)
-    results.sort_by { |r| -(r.metadata[:popularity] || 0) }
+  # 品質スコア（0.0〜1.0）: 画像あり=0.5, 説明あり=0.5
+  # 両方ある = 1.0、片方 = 0.5、どちらもない = 0.0
+  def quality_score(result)
+    score = 0.0
+    score += 0.5 if result.cover_image_url.present?
+    score += 0.5 if result.description.present?
+    score
+  end
+
+  # 品質スコア降順 → 人気度降順の2段ソート
+  # 情報がしっかりある結果を上位に並べることで、欠損結果を下位に押し下げる
+  def sort_by_quality_and_popularity(results)
+    results.sort_by do |r|
+      [-quality_score(r), -(r.metadata[:popularity] || 0)]
+    end
   end
 end

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -1,10 +1,21 @@
 # frozen_string_literal: true
 
-class WorkSearchService
+# 検索パイプラインは fetch → enrich_books → enrich_missing_descriptions →
+# share_series_descriptions → sort の順で処理する。各段階を private メソッドとして
+# 分割しているため行数は膨らむが、意味のある単位で命名しており責務は単一である。
+class WorkSearchService # rubocop:disable Metrics/ClassLength
   CACHE_TTL = 12.hours
   # 実装変更時にインクリメントしてキャッシュを無効化する
-  CACHE_VERSION = 'v2'
+  CACHE_VERSION = 'v3'
   ENRICHMENT_BATCH_SIZE = 5
+
+  # シリーズもの（Season N, OVA, 完結編, 第N期 等）を検出する正規表現
+  # "進撃の巨人 Season 2" → ["進撃の巨人", "Season 2"]
+  # "進撃の巨人 完結編 前編" → ["進撃の巨人", "完結編 前編"]
+  # 親タイトル（最短マッチ）+ 半角/全角スペース + シリーズ識別子 の構造で検出する
+  # rubocop:disable Layout/LineLength
+  SERIES_PATTERN = /\A(.+?)[\s　]+(Season[\s　]*[\d０-９]+.*|Part[\s　]*[\d０-９]+.*|OVA.*|Special.*|The[\s　]*Final[\s　]*Season.*|Final[\s　]*Season.*|完結編.*|外伝.*|第[\d０-９]+期.*|シーズン[\s　]*[\d０-９]+.*|劇場版.*)\z/i
+  # rubocop:enable Layout/LineLength
 
   def search(query, media_type: nil)
     cache_key = "work_search:#{CACHE_VERSION}:#{media_type || 'all'}:#{query}"
@@ -16,6 +27,7 @@ class WorkSearchService
 
       enrich_books_via_openbd(results)
       enrich_missing_descriptions(results)
+      share_series_descriptions(results)
       sort_by_quality_and_popularity(results)
     end
   end
@@ -157,6 +169,65 @@ class WorkSearchService
 
     ascii_ratio = text.count("\x20-\x7E").to_f / text.length
     ascii_ratio > 0.5
+  end
+
+  # シリーズ作品（"進撃の巨人 Season 2" 等）の説明欄が英語のままの場合に、
+  # 同じ検索結果リスト内に存在する親作品（"進撃の巨人"）の日本語説明を流用する
+  # 各シーズン固有の日本語説明データが世の中に存在しないため、シリーズ全体の概要として使う
+  # 流用した結果には metadata[:description_from_parent] = true を付与し、
+  # フロント側で「※シリーズ全体の説明」と注釈表示する
+  def share_series_descriptions(results)
+    parents = build_parent_map(results)
+    return if parents.empty?
+
+    results.each do |result|
+      next unless needs_parent_description?(result)
+
+      parent = find_matching_parent(result, parents)
+      next unless parent
+
+      result.description = parent.description
+      result.metadata[:description_from_parent] = true
+    end
+  end
+
+  # 親候補の正規化タイトル → 親 result のマップを構築する
+  # 親候補の条件: シリーズ識別子を含まず、日本語説明を持っている
+  def build_parent_map(results)
+    results.each_with_object({}) do |r, map|
+      next if series_subitem?(r.title)
+      next if r.description.blank? || english_text?(r.description)
+
+      map[normalize_for_parent_match(r.title)] = r
+    end
+  end
+
+  # 親説明流用が必要かどうか判定する
+  # 説明が空 or 英語の場合のみ補完対象（既に日本語説明があるなら流用しない）
+  def needs_parent_description?(result)
+    result.description.blank? || english_text?(result.description)
+  end
+
+  # 結果のタイトルからシリーズ親を探す
+  # "進撃の巨人 Season 2" → 親候補 "進撃の巨人" → parents マップから取得
+  def find_matching_parent(result, parents)
+    match = SERIES_PATTERN.match(result.title)
+    return nil unless match
+
+    parent_title = match[1].to_s.strip
+    return nil if parent_title.blank?
+
+    parents[normalize_for_parent_match(parent_title)]
+  end
+
+  # シリーズ識別子（Season N, OVA, 完結編 等）を持つ作品か判定
+  def series_subitem?(title)
+    SERIES_PATTERN.match?(title)
+  end
+
+  # 親マッチ用の表記揺れ吸収（NFKC + 大小文字 + 空白除去）
+  def normalize_for_parent_match(text)
+    text.unicode_normalize(:nfkc).downcase.gsub(/\s+/, '')
   end
 
   # 品質スコア（0.0〜1.0）: 画像あり=0.5, 説明あり=0.5

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -2,10 +2,12 @@
 
 class WorkSearchService
   CACHE_TTL = 12.hours
+  # 実装変更時にインクリメントしてキャッシュを無効化する
+  CACHE_VERSION = 'v2'
   ENRICHMENT_BATCH_SIZE = 5
 
   def search(query, media_type: nil)
-    cache_key = "work_search:#{media_type || 'all'}:#{query}"
+    cache_key = "work_search:#{CACHE_VERSION}:#{media_type || 'all'}:#{query}"
 
     Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
       adapters = select_adapters(media_type)

--- a/backend/spec/services/external_apis/google_books_adapter_spec.rb
+++ b/backend/spec/services/external_apis/google_books_adapter_spec.rb
@@ -78,5 +78,37 @@ RSpec.describe ExternalApis::GoogleBooksAdapter, type: :service do
       expect(WebMock).to have_requested(:get, /www.googleapis.com/)
         .with(query: hash_including(q: 'intitle:三体'))
     end
+
+    describe 'ISBN抽出' do
+      # テストごとに変わるのは industryIdentifiers のみなので、共通部分をヘルパー化
+      def build_book_item(identifiers: nil)
+        volume_info = { 'title' => 'テスト本' }
+        volume_info['industryIdentifiers'] = identifiers if identifiers
+        { 'id' => 'abc123', 'volumeInfo' => volume_info }
+      end
+
+      it 'ISBN-13 が最優先でmetadataに入る' do
+        stub_books_response([build_book_item(identifiers: [
+                                               { 'type' => 'ISBN_10', 'identifier' => '4101001340' },
+                                               { 'type' => 'ISBN_13', 'identifier' => '9784101001340' }
+                                             ])])
+        book = adapter.search('テスト本').first
+        expect(book.metadata[:isbn]).to eq('9784101001340')
+      end
+
+      it 'ISBN-13 がなければ ISBN-10 を使う' do
+        stub_books_response([build_book_item(identifiers: [
+                                               { 'type' => 'ISBN_10', 'identifier' => '4101001340' }
+                                             ])])
+        book = adapter.search('テスト本').first
+        expect(book.metadata[:isbn]).to eq('4101001340')
+      end
+
+      it 'ISBN情報がなければ :isbn キーは含まれない' do
+        stub_books_response([build_book_item])
+        book = adapter.search('テスト本').first
+        expect(book.metadata).not_to have_key(:isbn)
+      end
+    end
   end
 end

--- a/backend/spec/services/external_apis/openbd_client_spec.rb
+++ b/backend/spec/services/external_apis/openbd_client_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require 'webmock/rspec'
+
+RSpec.describe ExternalApis::OpenbdClient, type: :service do
+  subject(:client) { described_class.new }
+
+  describe '#fetch' do
+    context 'ISBNが空の場合' do
+      it 'nil を返す' do
+        expect(client.fetch(nil)).to be_nil
+        expect(client.fetch('')).to be_nil
+      end
+    end
+
+    context '正常なレスポンスの場合' do
+      let(:valid_response) do
+        [
+          {
+            'summary' => {
+              'isbn' => '9784101001340',
+              'title' => '人間失格',
+              'cover' => 'https://cover.openbd.jp/9784101001340.jpg'
+            },
+            'onix' => {
+              'CollateralDetail' => {
+                'TextContent' => [
+                  { 'TextType' => '03', 'Text' => '恥の多い生涯を送って来ました。' },
+                  { 'TextType' => '02', 'Text' => '著者: 太宰治' }
+                ]
+              }
+            }
+          }
+        ]
+      end
+
+      before do
+        stub_request(:get, %r{api.openbd.jp/v1/get})
+          .to_return(status: 200, body: valid_response.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it '画像URLと内容紹介を返す' do
+        result = client.fetch('9784101001340')
+        expect(result[:cover_image_url]).to eq('https://cover.openbd.jp/9784101001340.jpg')
+        expect(result[:description]).to eq('恥の多い生涯を送って来ました。')
+      end
+
+      it 'TextType=03（内容紹介）を優先して選ぶ' do
+        result = client.fetch('9784101001340')
+        expect(result[:description]).to eq('恥の多い生涯を送って来ました。')
+        expect(result[:description]).not_to include('著者')
+      end
+    end
+
+    context 'ISBNが見つからない場合' do
+      before do
+        # openBDは該当なしの時 [null] を返す
+        stub_request(:get, %r{api.openbd.jp/v1/get})
+          .to_return(status: 200, body: [nil].to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'nil を返す' do
+        expect(client.fetch('9999999999999')).to be_nil
+      end
+    end
+
+    context '画像が欠損している場合' do
+      let(:partial_response) do
+        [{
+          'summary' => { 'isbn' => '9784101001340', 'title' => 'テスト' },
+          'onix' => {
+            'CollateralDetail' => {
+              'TextContent' => [{ 'TextType' => '03', 'Text' => '説明文' }]
+            }
+          }
+        }]
+      end
+
+      before do
+        stub_request(:get, %r{api.openbd.jp/v1/get})
+          .to_return(status: 200, body: partial_response.to_json,
+                     headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it '画像URLは nil、説明は返す' do
+        result = client.fetch('9784101001340')
+        expect(result[:cover_image_url]).to be_nil
+        expect(result[:description]).to eq('説明文')
+      end
+    end
+
+    context 'ネットワークエラーの場合' do
+      before do
+        stub_request(:get, %r{api.openbd.jp/v1/get}).to_timeout
+      end
+
+      it 'nil を返しエラーを握りつぶす' do
+        expect(client.fetch('9784101001340')).to be_nil
+      end
+    end
+  end
+end

--- a/backend/spec/services/external_apis/title_matcher_spec.rb
+++ b/backend/spec/services/external_apis/title_matcher_spec.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ExternalApis::TitleMatcher, type: :service do
+  describe '.title_match?' do
+    context 'クエリと候補が完全一致する場合' do
+      it 'true を返す' do
+        expect(described_class.title_match?('呪術廻戦', '呪術廻戦')).to be true
+      end
+    end
+
+    context '全角/半角の表記揺れがある場合' do
+      it 'NFKC 正規化で全角!と半角!を同一視する' do
+        expect(described_class.title_match?('けいおん！', 'けいおん!')).to be true
+      end
+
+      it '全角英数字と半角英数字を同一視する' do
+        expect(described_class.title_match?('ＡＫＩＲＡ', 'AKIRA')).to be true
+      end
+    end
+
+    context '大小文字の差がある場合' do
+      it 'downcase で同一視する' do
+        expect(described_class.title_match?('Attack on Titan', 'ATTACK ON TITAN')).to be true
+      end
+    end
+
+    context '空白の有無が異なる場合' do
+      it '空白を除去して比較する' do
+        expect(described_class.title_match?('Attack on Titan', 'AttackonTitan')).to be true
+      end
+    end
+
+    context 'クエリにシリーズ識別子が付き、候補が親作品の場合' do
+      it 'クエリが候補の1.5倍以上長く含む場合は false（親作品却下）' do
+        # '進撃の巨人 Season 2' (12) vs '進撃の巨人' (5) → 1.5倍以上 + 含む
+        expect(described_class.title_match?('進撃の巨人 Season 2', '進撃の巨人')).to be false
+      end
+
+      it 'OVA サフィックスでも親作品を弾く' do
+        expect(described_class.title_match?('進撃の巨人 OVA', '進撃の巨人')).to be false
+      end
+
+      it '第2期 サフィックスでも親作品を弾く' do
+        expect(described_class.title_match?('呪術廻戦 第2期', '呪術廻戦')).to be false
+      end
+
+      it '完結編 サブタイトルでも親作品を弾く' do
+        expect(described_class.title_match?('進撃の巨人 完結編 前編', '進撃の巨人')).to be false
+      end
+    end
+
+    context '逆方向（候補がクエリの1.5倍以上長く含む場合）' do
+      it 'false を返す' do
+        expect(described_class.title_match?('進撃の巨人', '進撃の巨人 Season 2')).to be false
+      end
+    end
+
+    context '部分一致（軽微な表記揺れ）の場合' do
+      it '長さ比が1.5倍未満で部分一致するなら true' do
+        # 表記揺れ例: 短い差分（記号など）を許容したい
+        expect(described_class.title_match?('ABCDE', 'ABCDEF')).to be true
+      end
+    end
+
+    context 'クエリまたは候補が空の場合' do
+      it 'クエリが nil なら false' do
+        expect(described_class.title_match?(nil, '進撃の巨人')).to be false
+      end
+
+      it 'クエリが空文字なら false' do
+        expect(described_class.title_match?('', '進撃の巨人')).to be false
+      end
+
+      it '候補が nil なら false' do
+        expect(described_class.title_match?('進撃の巨人', nil)).to be false
+      end
+    end
+  end
+
+  describe '.normalize_for_match' do
+    it 'NFKC 正規化と downcase と空白除去を組み合わせる' do
+      # 全角ＡＢＣ → 半角abc、空白除去
+      expect(described_class.normalize_for_match('ＡＢＣ DEF')).to eq('abcdef')
+    end
+  end
+end

--- a/backend/spec/services/external_apis/title_matcher_spec.rb
+++ b/backend/spec/services/external_apis/title_matcher_spec.rb
@@ -33,8 +33,8 @@ RSpec.describe ExternalApis::TitleMatcher, type: :service do
     end
 
     context 'クエリにシリーズ識別子が付き、候補が親作品の場合' do
-      it 'クエリが候補の1.5倍以上長く含む場合は false（親作品却下）' do
-        # '進撃の巨人 Season 2' (12) vs '進撃の巨人' (5) → 1.5倍以上 + 含む
+      it 'クエリが親と異なる接尾辞を持つ場合は false（normalize後の完全一致のみ採用）' do
+        # '進撃の巨人 Season 2' と '進撃の巨人' は normalize 後でも別物
         expect(described_class.title_match?('進撃の巨人 Season 2', '進撃の巨人')).to be false
       end
 
@@ -51,16 +51,37 @@ RSpec.describe ExternalApis::TitleMatcher, type: :service do
       end
     end
 
-    context '逆方向（候補がクエリの1.5倍以上長く含む場合）' do
-      it 'false を返す' do
+    context '逆方向（候補の方が長い場合）' do
+      it 'false を返す（normalize後の完全一致のみ採用）' do
         expect(described_class.title_match?('進撃の巨人', '進撃の巨人 Season 2')).to be false
       end
     end
 
-    context '部分一致（軽微な表記揺れ）の場合' do
-      it '長さ比が1.5倍未満で部分一致するなら true' do
-        # 表記揺れ例: 短い差分（記号など）を許容したい
-        expect(described_class.title_match?('ABCDE', 'ABCDEF')).to be true
+    context '短いタイトルでの誤マッチ防止' do
+      it '短いタイトル + 1.5倍以下の部分一致は false（呪術廻戦 vs 呪術廻戦 0 等）' do
+        expect(described_class.title_match?('呪術廻戦 0', '呪術廻戦')).to be false
+      end
+
+      it 'タイトルがほぼ等しいが1文字違うナンバリング（FF vs FFX 等）は false' do
+        expect(described_class.title_match?('FFX', 'FF')).to be false
+        expect(described_class.title_match?('ペルソナ4', 'ペルソナ')).to be false
+      end
+    end
+
+    context '英語クエリと日本語ローカライズ名の照合' do
+      it '英語クエリと日本語ローカライズ名は照合不能（false）であることを明示的にテスト' do
+        # AniList の title_english フォールバック経路で TMDB から日本語ローカライズ名が
+        # 返ってきた場合、 normalize 後も照合不能になることを文書化する
+        expect(described_class.title_match?('Attack on Titan', '進撃の巨人')).to be false
+        expect(described_class.title_match?('Steins;Gate', 'シュタインズ・ゲート')).to be false
+      end
+    end
+
+    context '不正な UTF-8 バイト列が含まれる場合' do
+      it '安全に false を返す' do
+        invalid = "\xff\xfe".dup.force_encoding('UTF-8')
+        expect(described_class.title_match?('進撃の巨人', invalid)).to be false
+        expect(described_class.title_match?(invalid, '進撃の巨人')).to be false
       end
     end
 
@@ -76,6 +97,11 @@ RSpec.describe ExternalApis::TitleMatcher, type: :service do
       it '候補が nil なら false' do
         expect(described_class.title_match?('進撃の巨人', nil)).to be false
       end
+
+      it '空白だけの文字列は false を返す（blank? で弾かれる）' do
+        expect(described_class.title_match?('   ', '進撃の巨人')).to be false
+        expect(described_class.title_match?('進撃の巨人', "\u3000\u3000")).to be false
+      end
     end
   end
 
@@ -83,6 +109,11 @@ RSpec.describe ExternalApis::TitleMatcher, type: :service do
     it 'NFKC 正規化と downcase と空白除去を組み合わせる' do
       # 全角ＡＢＣ → 半角abc、空白除去
       expect(described_class.normalize_for_match('ＡＢＣ DEF')).to eq('abcdef')
+    end
+
+    it '不正な UTF-8 バイト列に対しては空文字を返す' do
+      invalid = "\xff\xfe".dup.force_encoding('UTF-8')
+      expect(described_class.normalize_for_match(invalid)).to eq('')
     end
   end
 end

--- a/backend/spec/services/external_apis/tmdb_adapter_spec.rb
+++ b/backend/spec/services/external_apis/tmdb_adapter_spec.rb
@@ -333,8 +333,9 @@ RSpec.describe ExternalApis::TmdbAdapter, type: :service do
                    headers: { 'Content-Type' => 'application/json' })
     end
 
-    it 'TMDBの日本語概要を返す' do
-      description = adapter.fetch_japanese_description('K-ON!')
+    it 'TMDBの日本語概要を返す（クエリと結果名が一致する場合）' do
+      # 全角/半角の差は normalize で吸収される
+      description = adapter.fetch_japanese_description('けいおん!')
       expect(description).to eq('桜が丘高校の軽音部に入部した4人の少女たちの日常')
     end
 
@@ -352,8 +353,10 @@ RSpec.describe ExternalApis::TmdbAdapter, type: :service do
 
     it '同名の外国作品より日本語原語の作品を優先する' do
       mixed = { 'results' => [
-        { 'media_type' => 'movie', 'original_language' => 'en', 'overview' => 'American SF movie' },
-        { 'media_type' => 'tv', 'original_language' => 'ja', 'overview' => '巨人が支配する世界で人類が戦う' }
+        { 'media_type' => 'movie', 'name' => 'Attack on Titan', 'title' => 'Attack on Titan',
+          'original_language' => 'en', 'overview' => 'American SF movie' },
+        { 'media_type' => 'tv', 'name' => 'Attack on Titan',
+          'original_language' => 'ja', 'overview' => '巨人が支配する世界で人類が戦う' }
       ] }
       stub_request(:get, %r{api.themoviedb.org/3/search/multi})
         .to_return(status: 200, body: mixed.to_json, headers: { 'Content-Type' => 'application/json' })
@@ -363,11 +366,37 @@ RSpec.describe ExternalApis::TmdbAdapter, type: :service do
     it '日本語原語の結果がない場合は最初のmovie/tvにフォールバックする' do
       english_only = { 'results' => [
         { 'media_type' => 'person' },
-        { 'media_type' => 'movie', 'original_language' => 'en', 'overview' => 'An English movie' }
+        { 'media_type' => 'movie', 'name' => 'Some Movie', 'title' => 'Some Movie',
+          'original_language' => 'en', 'overview' => 'An English movie' }
       ] }
       stub_request(:get, %r{api.themoviedb.org/3/search/multi})
         .to_return(status: 200, body: english_only.to_json, headers: { 'Content-Type' => 'application/json' })
       expect(adapter.fetch_japanese_description('Some Movie')).to eq('An English movie')
+    end
+
+    context 'シリーズもののクエリで TMDB が親作品を返す場合' do
+      before do
+        # query='進撃の巨人 Season 2' で TMDB は親作品 '進撃の巨人' を返してしまう
+        stub_request(:get, %r{api.themoviedb.org/3/search/multi})
+          .to_return(status: 200, body: {
+            'results' => [
+              { 'media_type' => 'tv', 'name' => '進撃の巨人',
+                'original_language' => 'ja', 'overview' => '繁栄を築き上げた人類は...' }
+            ]
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'Season 2 クエリで親作品の説明を返さない' do
+        expect(adapter.fetch_japanese_description('進撃の巨人 Season 2')).to be_nil
+      end
+
+      it 'OVA クエリで親作品の説明を返さない' do
+        expect(adapter.fetch_japanese_description('進撃の巨人 OVA')).to be_nil
+      end
+
+      it '完結編 サブタイトルで親作品の説明を返さない' do
+        expect(adapter.fetch_japanese_description('進撃の巨人 完結編 前編')).to be_nil
+      end
     end
   end
 

--- a/backend/spec/services/external_apis/wikipedia_client_spec.rb
+++ b/backend/spec/services/external_apis/wikipedia_client_spec.rb
@@ -164,7 +164,7 @@ RSpec.describe ExternalApis::WikipediaClient, type: :service do
   end
 
   describe '#search_and_fetch_extract' do
-    context '検索で記事が見つかる場合' do
+    context '検索結果のタイトルがクエリと一致する場合' do
       before do
         # 1回目: search API（query.list.search）
         stub_request(:get, /ja.wikipedia.org/)
@@ -186,8 +186,50 @@ RSpec.describe ExternalApis::WikipediaClient, type: :service do
       end
 
       it '検索→概要取得の2段階で日本語説明を返す' do
-        extract = client.search_and_fetch_extract('呪術廻戦 第2期')
+        extract = client.search_and_fetch_extract('呪術廻戦')
         expect(extract).to eq('呪術廻戦は芥見下々による日本の漫画作品。')
+      end
+    end
+
+    context '全角/半角の軽微な表記揺れがある場合' do
+      before do
+        # 全角!と半角!の表記揺れを吸収できるか確認
+        stub_request(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(list: 'search'))
+          .to_return(status: 200, body: {
+            'query' => { 'search' => [{ 'title' => 'けいおん!' }] }
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+        stub_request(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(prop: 'extracts'))
+          .to_return(status: 200, body: {
+            'query' => { 'pages' => { '1' => { 'title' => 'けいおん!', 'extract' => '軽音部の物語' } } }
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it '全角/半角の軽微な表記揺れは許容する' do
+        expect(client.search_and_fetch_extract('けいおん！')).to eq('軽音部の物語')
+      end
+    end
+
+    context 'クエリにシリーズ識別子が含まれ、検索が親作品を返す場合' do
+      before do
+        # query='進撃の巨人 Season 2' で検索 → Wikipedia は親記事 '進撃の巨人' を返す
+        stub_request(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(list: 'search'))
+          .to_return(status: 200, body: {
+            'query' => { 'search' => [{ 'title' => '進撃の巨人' }] }
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'タイトル一致しないため nil を返す（誤った親作品の説明を採用しない）' do
+        expect(client.search_and_fetch_extract('進撃の巨人 Season 2')).to be_nil
+        # 親記事の extract API は呼ばれない
+        expect(WebMock).not_to have_requested(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(prop: 'extracts'))
+      end
+
+      it 'OVA 等のサブタイトルでも親作品を弾く' do
+        expect(client.search_and_fetch_extract('進撃の巨人 OVA')).to be_nil
       end
     end
 

--- a/backend/spec/services/external_apis/wikipedia_client_spec.rb
+++ b/backend/spec/services/external_apis/wikipedia_client_spec.rb
@@ -162,4 +162,55 @@ RSpec.describe ExternalApis::WikipediaClient, type: :service do
       expect(client.fetch_categories(['テスト'])).to eq({})
     end
   end
+
+  describe '#search_and_fetch_extract' do
+    context '検索で記事が見つかる場合' do
+      before do
+        # 1回目: search API（query.list.search）
+        stub_request(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(list: 'search'))
+          .to_return(status: 200, body: {
+            'query' => {
+              'search' => [{ 'title' => '呪術廻戦' }]
+            }
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+
+        # 2回目: extract API（query.pages）
+        stub_request(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(prop: 'extracts'))
+          .to_return(status: 200, body: {
+            'query' => {
+              'pages' => { '1' => { 'title' => '呪術廻戦', 'extract' => '呪術廻戦は芥見下々による日本の漫画作品。' } }
+            }
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it '検索→概要取得の2段階で日本語説明を返す' do
+        extract = client.search_and_fetch_extract('呪術廻戦 第2期')
+        expect(extract).to eq('呪術廻戦は芥見下々による日本の漫画作品。')
+      end
+    end
+
+    context '検索で記事が0件の場合' do
+      before do
+        stub_request(:get, /ja.wikipedia.org/)
+          .with(query: hash_including(list: 'search'))
+          .to_return(status: 200, body: {
+            'query' => { 'search' => [] }
+          }.to_json, headers: { 'Content-Type' => 'application/json' })
+      end
+
+      it 'nil を返す' do
+        expect(client.search_and_fetch_extract('存在しない作品xyz123')).to be_nil
+      end
+    end
+
+    context 'クエリが空の場合' do
+      it 'nil を返しAPI呼び出しは発生しない' do
+        expect(client.search_and_fetch_extract('')).to be_nil
+        expect(client.search_and_fetch_extract(nil)).to be_nil
+        expect(WebMock).not_to have_requested(:get, /ja.wikipedia.org/)
+      end
+    end
+  end
 end

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -159,8 +159,10 @@ RSpec.describe WorkSearchService, type: :service do
     it 'ISBN がない結果は openBD 対象外' do
       allow(openbd_double).to receive(:fetch)
       service.search('本テスト', media_type: 'book')
-      # book_without_isbn に対する fetch 呼び出しがないことを確認
-      expect(openbd_double).to have_received(:fetch).with('9784101001340').at_most(:once)
+      # ISBNを持つ結果のfetchは呼ばれる
+      expect(openbd_double).to have_received(:fetch).with('9784101001340')
+      # ISBNがない結果に対するfetchは呼ばれない
+      expect(openbd_double).not_to have_received(:fetch).with(nil)
     end
   end
 

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -638,6 +638,71 @@ RSpec.describe WorkSearchService, type: :service do
       end
     end
     # rubocop:enable RSpec/MultipleMemoizedHelpers
+
+    # 親プレフィックスの直後が文字/数字の場合は同じ単語の続きと見なし別作品として除外する
+    # ratio 閾値（廃止）の代わりに境界文字判定で誤マッチを防ぐ
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'プレフィックスマッチの誤マッチ防止（境界文字判定）' do
+      def build_result(title, description, popularity)
+        ExternalApis::BaseAdapter::SearchResult.new(
+          title, 'anime', description, nil, 12, SecureRandom.hex(4), 'anilist', { popularity: popularity }
+        )
+      end
+
+      def stub_anilist_with(results)
+        allow(anilist_double).to receive(:safe_search).and_return(results)
+      end
+
+      it '親直後が日本語文字続きの場合は流用しない（進撃の巨人 → 進撃の巨人ファンクラブ）' do
+        parent = build_result('進撃の巨人', '繁栄を築き上げた人類は巨人により滅亡の淵に立たされた。', 1.0)
+        fanclub = build_result('進撃の巨人ファンクラブ', 'A fan club for Attack on Titan.', 0.1)
+        stub_anilist_with([parent, fanclub])
+        results = service.search('進撃の巨人', media_type: 'anime')
+        fc = results.find { |r| r.title == '進撃の巨人ファンクラブ' }
+        expect(fc.description).to eq('A fan club for Attack on Titan.')
+        expect(fc.metadata[:description_from_parent]).to be_nil
+      end
+
+      it '親直後が英文字の場合は流用しない（FATE → FATEstay）' do
+        parent = build_result('FATE', 'フェイト本編の日本語説明', 1.0)
+        other = build_result('FATEstay', 'Different work entirely', 0.5)
+        stub_anilist_with([parent, other])
+        results = service.search('FATE', media_type: 'anime')
+        o = results.find { |r| r.title == 'FATEstay' }
+        expect(o.description).to eq('Different work entirely')
+        expect(o.metadata[:description_from_parent]).to be_nil
+      end
+
+      it '親直後が日本語文字続きの場合は流用しない（呪術 → 呪術廻戦）' do
+        parent = build_result('呪術', '呪術の解説', 0.3)
+        other = build_result('呪術廻戦', 'Jujutsu Kaisen English description', 1.0)
+        stub_anilist_with([parent, other])
+        results = service.search('呪術', media_type: 'anime')
+        o = results.find { |r| r.title == '呪術廻戦' }
+        expect(o.description).to eq('Jujutsu Kaisen English description')
+        expect(o.metadata[:description_from_parent]).to be_nil
+      end
+
+      it '親直後が記号（":"）の場合は流用する（HUNTER×HUNTER → HUNTER×HUNTER: Greed Island）' do
+        parent = build_result('HUNTER×HUNTER', 'ハンターと呼ばれる人々がいる。', 0.9)
+        arc = build_result('HUNTER×HUNTER: Greed Island', 'After the battle.', 0.5)
+        stub_anilist_with([parent, arc])
+        results = service.search('HUNTER×HUNTER', media_type: 'anime')
+        a = results.find { |r| r.title == 'HUNTER×HUNTER: Greed Island' }
+        expect(a.description).to eq('ハンターと呼ばれる人々がいる。')
+      end
+
+      it '長尺タイトル（13字以上）でも短いシリーズ識別子が付けば流用する（PARENT_PREFIX_RATIO 廃止の検証）' do
+        parent = build_result('転生したらスライムだった件', '転生したスライムが異世界で...', 1.0)
+        season2 = build_result('転生したらスライムだった件 第2期', 'Slime continues his journey.', 0.9)
+        stub_anilist_with([parent, season2])
+        results = service.search('スライム', media_type: 'anime')
+        s2 = results.find { |r| r.title.include?('第2期') }
+        expect(s2.description).to eq('転生したスライムが異世界で...')
+        expect(s2.metadata[:description_from_parent]).to be true
+      end
+    end
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 
   describe 'キャッシュ' do
@@ -674,7 +739,7 @@ RSpec.describe WorkSearchService, type: :service do
       Rails.cache.write('work_search:anime:テスト', [mock_result])
       # 新しい検索は新しいキー形式で保存される
       service.search('テスト', media_type: 'anime')
-      expect(Rails.cache.exist?('work_search:v3:anime:テスト')).to be true
+      expect(Rails.cache.exist?('work_search:v4:anime:テスト')).to be true
     end
   end
 end

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -104,6 +104,66 @@ RSpec.describe WorkSearchService, type: :service do
     end
   end
 
+  describe '#search openBD補完' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:openbd_double) { instance_double(ExternalApis::OpenbdClient) }
+    let(:book_without_image) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '人間失格', 'book', nil, nil, nil, 'gbid1', 'google_books',
+        { isbn: '9784101001340', popularity: 0.5 }
+      )
+    end
+    let(:book_with_full_data) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        'ノルウェイの森', 'book', '既存の説明', 'https://existing.jpg',
+        nil, 'gbid2', 'google_books',
+        { isbn: '9784101001341', popularity: 0.5 }
+      )
+    end
+    let(:book_without_isbn) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '謎の本', 'book', nil, nil, nil, 'gbid3', 'google_books',
+        { popularity: 0.5 }
+      )
+    end
+
+    before do
+      allow(ExternalApis::OpenbdClient).to receive(:new).and_return(openbd_double)
+      allow(google_books_double).to receive(:safe_search).and_return(
+        [book_without_image, book_with_full_data, book_without_isbn]
+      )
+    end
+
+    it 'ISBN がある欠損結果に openBD のデータを補完する' do
+      allow(openbd_double).to receive(:fetch).with('9784101001340').and_return(
+        { cover_image_url: 'https://openbd.jp/cover.jpg', description: '恥の多い生涯。' }
+      )
+      results = service.search('本テスト', media_type: 'book')
+      target = results.find { |r| r.title == '人間失格' }
+      expect(target.cover_image_url).to eq('https://openbd.jp/cover.jpg')
+      expect(target.description).to eq('恥の多い生涯。')
+    end
+
+    it '既存のデータは openBD で上書きしない' do
+      allow(openbd_double).to receive(:fetch).and_return(
+        { cover_image_url: 'https://openbd.jp/other.jpg', description: '別の説明' }
+      )
+      results = service.search('本テスト', media_type: 'book')
+      target = results.find { |r| r.title == 'ノルウェイの森' }
+      # 既存の画像・説明が維持される
+      expect(target.cover_image_url).to eq('https://existing.jpg')
+      expect(target.description).to eq('既存の説明')
+      # openBD fetch は呼ばれない（欠損がないため）
+      expect(openbd_double).not_to have_received(:fetch).with('9784101001341')
+    end
+
+    it 'ISBN がない結果は openBD 対象外' do
+      allow(openbd_double).to receive(:fetch)
+      service.search('本テスト', media_type: 'book')
+      # book_without_isbn に対する fetch 呼び出しがないことを確認
+      expect(openbd_double).to have_received(:fetch).with('9784101001340').at_most(:once)
+    end
+  end
+
   describe '人気順ソート' do
     let(:low_pop) do
       ExternalApis::BaseAdapter::SearchResult.new(

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -330,5 +330,13 @@ RSpec.describe WorkSearchService, type: :service do
       expect(anilist_double).to have_received(:safe_search).twice
       expect(tmdb_double).to have_received(:safe_search).exactly(:once)
     end
+
+    it 'キャッシュキーに CACHE_VERSION を含めることで古い実装のキャッシュを無視する' do
+      # 古いフォーマットのキー（v無し）でデータを入れておく
+      Rails.cache.write('work_search:anime:テスト', [mock_result])
+      # 新しい検索は新しいキー形式で保存される
+      service.search('テスト', media_type: 'anime')
+      expect(Rails.cache.exist?('work_search:v2:anime:テスト')).to be true
+    end
   end
 end

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -580,6 +580,64 @@ RSpec.describe WorkSearchService, type: :service do
       expect(season3.description).to eq('母親の命を奪った巨人を駆逐するため戦う。')
       expect(season3.metadata[:description_from_parent]).to be_nil
     end
+
+    # プレフィックスマッチで対応する幅広いシリーズパターンを検証する
+    # ビルダーで SearchResult 生成を 1 行化し、例あたりの行数を抑えて RSpec/ExampleLength を満たす
+    # rubocop:disable RSpec/MultipleMemoizedHelpers
+    context 'プレフィックスマッチによる幅広いシリーズ識別子対応' do
+      def build_result(title, description, popularity)
+        ExternalApis::BaseAdapter::SearchResult.new(
+          title, 'anime', description, nil, 12, SecureRandom.hex(4), 'anilist', { popularity: popularity }
+        )
+      end
+
+      def stub_anilist_with(results)
+        allow(anilist_double).to receive(:safe_search).and_return(results)
+      end
+
+      it '"2nd Season" のような英語序数パターンも流用する' do
+        parent = build_result('Re:ゼロから始める異世界生活', '無力な少年が手にしたのは、死して時間を巻き戻す力。', 1.0)
+        child = build_result('Re:ゼロから始める異世界生活 2nd Season', 'Even after dying countless times, Subaru.', 0.9)
+        stub_anilist_with([parent, child])
+        matched = service.search('Re:ゼロ', media_type: 'anime').find { |r| r.title.include?('2nd Season') }
+        expect(matched.description).to eq('無力な少年が手にしたのは、死して時間を巻き戻す力。')
+        expect(matched.metadata[:description_from_parent]).to be true
+      end
+
+      it '年号サフィックス（HUNTER×HUNTER (2011) 等）も流用する' do
+        parent = build_result('HUNTER×HUNTER', 'ハンターと呼ばれる人々がいる。', 0.9)
+        remake = build_result('HUNTER×HUNTER (2011)', 'A new adaption of the manga.', 1.0)
+        stub_anilist_with([parent, remake])
+        matched = service.search('HUNTER×HUNTER', media_type: 'anime').find { |r| r.title == 'HUNTER×HUNTER (2011)' }
+        expect(matched.description).to eq('ハンターと呼ばれる人々がいる。')
+      end
+
+      it 'コロン区切りサブタイトル（HUNTER×HUNTER: Greed Island 等）も流用する' do
+        parent = build_result('HUNTER×HUNTER', 'ハンターと呼ばれる人々がいる。', 0.9)
+        arc = build_result('HUNTER×HUNTER: Greed Island', 'After the battle with the Spiders.', 0.5)
+        stub_anilist_with([parent, arc])
+        matched = service.search('HUNTER×HUNTER', media_type: 'anime').find { |r| r.title.include?('Greed Island') }
+        expect(matched.description).to eq('ハンターと呼ばれる人々がいる。')
+      end
+
+      it '任意の日本語サブタイトル（横行跋扈のポリオマニア 等）も流用する' do
+        parent = build_result('シュタインズ・ゲート', '岡部倫太郎が時間軸を巡る物語。', 1.0)
+        spinoff = build_result('シュタインズ・ゲート 横行跋扈のポリオマニア', 'Special episode included.', 0.3)
+        stub_anilist_with([parent, spinoff])
+        matched = service.search('シュタインズ・ゲート', media_type: 'anime').find { |r| r.title.include?('横行跋扈') }
+        expect(matched.description).to eq('岡部倫太郎が時間軸を巡る物語。')
+      end
+
+      it '親が複数候補ある場合、より長くマッチする親を優先する' do
+        short_parent = build_result('進撃の', '短い親の説明', 0.5)
+        long_parent = build_result('進撃の巨人', '長い親の正しい説明', 1.0)
+        child = build_result('進撃の巨人 Season 2', 'English desc', 0.9)
+        stub_anilist_with([short_parent, long_parent, child])
+        matched = service.search('進撃の巨人', media_type: 'anime').find { |r| r.title == '進撃の巨人 Season 2' }
+        expect(matched.description).to eq('長い親の正しい説明')
+      end
+    end
+    # rubocop:enable RSpec/MultipleMemoizedHelpers
   end
 
   describe 'キャッシュ' do

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -26,10 +26,11 @@ RSpec.describe WorkSearchService, type: :service do
     allow(ExternalApis::GoogleBooksAdapter).to receive(:new).and_return(google_books_double)
     allow(ExternalApis::IgdbAdapter).to receive(:new).and_return(igdb_double)
     # Wikipedia補完のデフォルト（見つからない場合）
-    wiki_double = instance_double(ExternalApis::WikipediaClient, fetch_extract: nil)
+    # Task 6 で fetch_extract から search_and_fetch_extract に切り替えた
+    wiki_double = instance_double(ExternalApis::WikipediaClient, search_and_fetch_extract: nil)
     allow(ExternalApis::WikipediaClient).to receive(:new).and_return(wiki_double)
     # instance_spy はnull objectのため、スタブしないと自身を返す
-    # enrich_anilist_descriptions で description に spy が入りマーシャリング失敗を防ぐ
+    # enrich_missing_descriptions で description に spy が入りマーシャリング失敗を防ぐ
     allow(tmdb_double).to receive_messages(safe_search: [], fetch_japanese_description: nil)
     allow(anilist_double).to receive(:safe_search).and_return([mock_result])
     allow(google_books_double).to receive(:safe_search).and_return([])
@@ -197,8 +198,10 @@ RSpec.describe WorkSearchService, type: :service do
     end
   end
 
-  describe '英語説明文の除去' do
-    it 'IGDB等の英語説明文をnilにする' do
+  describe '英語説明の保持' do
+    # Task 6 以降: 破壊的な remove_english_descriptions を廃止し、
+    # Wikipedia/TMDBで日本語説明が取れなかった場合は英語をそのまま残す方針に変更した
+    it 'IGDB等の英語説明文は補完できなくても元の英語のまま残す' do
       english_game = ExternalApis::BaseAdapter::SearchResult.new(
         'Elden Ring', 'game', 'An action RPG developed by FromSoftware.',
         nil, nil, '119133', 'igdb', { popularity: 0.9 }
@@ -207,10 +210,10 @@ RSpec.describe WorkSearchService, type: :service do
       allow(anilist_double).to receive(:safe_search).and_return([])
 
       results = service.search('エルデンリング')
-      expect(results.first.description).to be_nil
+      expect(results.first.description).to eq('An action RPG developed by FromSoftware.')
     end
 
-    it '日本語の説明文は除去しない' do
+    it '日本語の説明文はそのまま維持する' do
       japanese_game = ExternalApis::BaseAdapter::SearchResult.new(
         'モンスターハンター', 'game', 'カプコンが開発したアクションゲーム。',
         nil, nil, '1111', 'igdb', { popularity: 0.8 }
@@ -231,7 +234,10 @@ RSpec.describe WorkSearchService, type: :service do
         { popularity: 1.0, title_english: 'Attack on Titan', title_romaji: 'Shingeki no Kyojin' }
       )
     end
-    let(:wikipedia_client_double) { instance_double(ExternalApis::WikipediaClient, fetch_extract: nil) }
+    # Task 6 で fetch_extract から search_and_fetch_extract に変更
+    let(:wikipedia_client_double) do
+      instance_double(ExternalApis::WikipediaClient, search_and_fetch_extract: nil)
+    end
 
     before do
       allow(anilist_double).to receive(:safe_search).and_return([anilist_result])
@@ -247,11 +253,12 @@ RSpec.describe WorkSearchService, type: :service do
       expect(results.first.description).to eq('巨人が支配する世界で人類が生き残りをかけて戦う')
     end
 
-    it 'TMDBでもWikipediaでも見つからない場合は英語説明を除去する' do
+    # Task 6 で破壊的な英語説明除去を廃止したため、英語が残る方向に期待値を更新
+    it 'TMDBでもWikipediaでも見つからない場合は英語説明をそのまま残す' do
       allow(tmdb_double).to receive(:fetch_japanese_description).and_return(nil)
 
       results = service.search('マイナーアニメ')
-      expect(results.first.description).to be_nil
+      expect(results.first.description).to eq('In a world ruled by giants...')
     end
 
     it '日本語タイトルで見つからない場合、英語→ローマ字の順にフォールバックする' do # rubocop:disable RSpec/ExampleLength
@@ -297,24 +304,27 @@ RSpec.describe WorkSearchService, type: :service do
         allow(tmdb_double).to receive(:fetch_japanese_description).and_return(nil)
       end
 
+      # Task 6 で fetch_extract → search_and_fetch_extract に切り替え
       it 'TMDBで見つからない場合、Wikipediaから日本語説明を取得する' do
-        allow(wikipedia_client_double).to receive(:fetch_extract)
+        allow(wikipedia_client_double).to receive(:search_and_fetch_extract)
           .with('マイナーアニメ').and_return('マイナーアニメは、日本のテレビアニメ作品。')
 
         results = service.search('マイナーアニメ')
         expect(results.first.description).to eq('マイナーアニメは、日本のテレビアニメ作品。')
       end
 
-      it 'TMDBでもWikipediaでも見つからない場合、英語説明を除去する' do
-        allow(wikipedia_client_double).to receive(:fetch_extract)
+      # Task 6 で破壊的な英語除去を廃止したため、英語が残る期待に変更
+      it 'TMDBでもWikipediaでも見つからない場合、英語説明を残す' do
+        allow(wikipedia_client_double).to receive(:search_and_fetch_extract)
           .with('マイナーアニメ').and_return(nil)
 
         results = service.search('マイナーアニメ')
-        expect(results.first.description).to be_nil
+        expect(results.first.description).to eq('A minor anime series.')
       end
     end
 
-    it '日本語説明が見つからなかった場合、英語説明を除去する' do
+    # Task 6 で破壊的な英語除去を廃止したため、英語が残る期待に変更
+    it '日本語説明が見つからなかった場合、英語説明をそのまま残す' do
       english_anime = ExternalApis::BaseAdapter::SearchResult.new(
         'マイナーOVA', 'anime', 'This is a minor OVA episode.',
         nil, 1, '88888', 'anilist',
@@ -324,7 +334,7 @@ RSpec.describe WorkSearchService, type: :service do
       allow(tmdb_double).to receive(:fetch_japanese_description).and_return(nil)
 
       results = service.search('マイナーOVA')
-      expect(results.first.description).to be_nil
+      expect(results.first.description).to eq('This is a minor OVA episode.')
     end
 
     context '複数AniList結果の並列補完' do # rubocop:disable RSpec/MultipleMemoizedHelpers
@@ -361,6 +371,67 @@ RSpec.describe WorkSearchService, type: :service do
         descriptions = results.map(&:description)
         expect(descriptions).to contain_exactly('作品Aの日本語説明', '作品Bの日本語説明')
       end
+    end
+  end
+
+  describe '#search 全ソース対象のWikipedia補完' do
+    let(:wiki_double) { instance_double(ExternalApis::WikipediaClient) }
+    let(:igdb_result) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        'Zelda', 'game', 'An action-adventure game series.', 'https://img.igdb', nil,
+        'g1', 'igdb', { popularity: 0.9 }
+      )
+    end
+    let(:google_book_without_desc) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '嫌われる勇気', 'book', nil, 'https://img.gbooks', nil,
+        'gb1', 'google_books', { isbn: '9784478025819', popularity: 0.8 }
+      )
+    end
+
+    before do
+      allow(ExternalApis::WikipediaClient).to receive(:new).and_return(wiki_double)
+      allow(ExternalApis::OpenbdClient).to receive(:new).and_return(
+        instance_double(ExternalApis::OpenbdClient, fetch: nil)
+      )
+    end
+
+    it 'IGDB（ゲーム）の英語説明も Wikipedia 補完の対象になる' do
+      allow(wiki_double).to receive(:search_and_fetch_extract).with('Zelda')
+                                                              .and_return('ゼルダの伝説はアクションアドベンチャーゲーム。')
+      allow(igdb_double).to receive(:safe_search).and_return([igdb_result])
+
+      results = service.search('Zelda', media_type: 'game')
+      expect(results.first.description).to eq('ゼルダの伝説はアクションアドベンチャーゲーム。')
+    end
+
+    it 'Google Books の空説明も Wikipedia 補完の対象になる' do
+      allow(wiki_double).to receive(:search_and_fetch_extract).with('嫌われる勇気')
+                                                              .and_return('嫌われる勇気はアドラー心理学の入門書。')
+      allow(google_books_double).to receive(:safe_search).and_return([google_book_without_desc])
+
+      results = service.search('嫌われる勇気', media_type: 'book')
+      expect(results.first.description).to eq('嫌われる勇気はアドラー心理学の入門書。')
+    end
+
+    it 'Wikipedia で見つからず英語しかない場合は英語説明を残す' do
+      allow(wiki_double).to receive(:search_and_fetch_extract).and_return(nil)
+      allow(igdb_double).to receive(:safe_search).and_return([igdb_result])
+
+      results = service.search('Zelda', media_type: 'game')
+      # nil にはならず、元の英語説明が残る（破壊的削除の廃止）
+      expect(results.first.description).to eq('An action-adventure game series.')
+    end
+
+    it 'TMDBで日本語説明が取れれば Wikipedia を呼ばない' do
+      # TMDBアダプタのフェッチをモック
+      allow(tmdb_double).to receive(:fetch_japanese_description).and_return('ゲーム日本語説明')
+      allow(wiki_double).to receive(:search_and_fetch_extract)
+      allow(igdb_double).to receive(:safe_search).and_return([igdb_result])
+
+      results = service.search('Zelda', media_type: 'game')
+      expect(results.first.description).to eq('ゲーム日本語説明')
+      expect(wiki_double).not_to have_received(:search_and_fetch_extract)
     end
   end
 

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -486,6 +486,102 @@ RSpec.describe WorkSearchService, type: :service do
     end
   end
 
+  describe '#search シリーズ親説明流用' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:parent_with_japanese) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '進撃の巨人', 'anime', '繁栄を築き上げた人類は巨人により滅亡の淵に立たされた。',
+        'https://img.parent', 25, '1', 'anilist', { popularity: 1.0 }
+      )
+    end
+    let(:season2_english) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '進撃の巨人 Season 2', 'anime', 'Eren Jaeger swore to wipe out every last Titan.',
+        'https://img.s2', 12, '2', 'anilist', { popularity: 0.9 }
+      )
+    end
+    let(:final_season_english) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '進撃の巨人 The Final Season', 'anime', 'It has been four years since the Scout Regiment.',
+        'https://img.fs', 16, '3', 'anilist', { popularity: 0.8 }
+      )
+    end
+    let(:gaiden_english) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '進撃の巨人 外伝 悔いなき選択', 'anime', 'This prequel to megahit Attack on Titan.',
+        nil, 2, '4', 'anilist', { popularity: 0.5 }
+      )
+    end
+
+    before do
+      # Wikipedia/TMDB 補完はバイパス（親の日本語は既に取れている前提）
+      wiki = instance_double(ExternalApis::WikipediaClient, search_and_fetch_extract: nil)
+      allow(ExternalApis::WikipediaClient).to receive(:new).and_return(wiki)
+      allow(tmdb_double).to receive(:fetch_japanese_description).and_return(nil)
+      allow(anilist_double).to receive(:safe_search).and_return(
+        [parent_with_japanese, season2_english, final_season_english, gaiden_english]
+      )
+    end
+
+    it 'シリーズ子の英語説明を親の日本語説明で流用する' do
+      results = service.search('進撃の巨人', media_type: 'anime')
+      season2 = results.find { |r| r.title == '進撃の巨人 Season 2' }
+      expect(season2.description).to eq('繁栄を築き上げた人類は巨人により滅亡の淵に立たされた。')
+    end
+
+    it '流用した子に metadata[:description_from_parent] = true を付与する' do
+      results = service.search('進撃の巨人', media_type: 'anime')
+      season2 = results.find { |r| r.title == '進撃の巨人 Season 2' }
+      expect(season2.metadata[:description_from_parent]).to be true
+    end
+
+    it '親自身は流用対象にならない（自分の説明を保持し、フラグも付かない）' do
+      results = service.search('進撃の巨人', media_type: 'anime')
+      parent = results.find { |r| r.title == '進撃の巨人' }
+      expect(parent.description).to eq('繁栄を築き上げた人類は巨人により滅亡の淵に立たされた。')
+      expect(parent.metadata[:description_from_parent]).to be_nil
+    end
+
+    it 'The Final Season や 外伝 など複数のシリーズ識別子パターンで流用する' do
+      results = service.search('進撃の巨人', media_type: 'anime')
+      final = results.find { |r| r.title == '進撃の巨人 The Final Season' }
+      gaiden = results.find { |r| r.title == '進撃の巨人 外伝 悔いなき選択' }
+      expect(final.description).to eq('繁栄を築き上げた人類は巨人により滅亡の淵に立たされた。')
+      expect(gaiden.description).to eq('繁栄を築き上げた人類は巨人により滅亡の淵に立たされた。')
+    end
+
+    it '親が結果に含まれない場合は流用せず英語のまま残す' do
+      allow(anilist_double).to receive(:safe_search).and_return([season2_english])
+      results = service.search('進撃の巨人 Season 2', media_type: 'anime')
+      expect(results.first.description).to eq('Eren Jaeger swore to wipe out every last Titan.')
+      expect(results.first.metadata[:description_from_parent]).to be_nil
+    end
+
+    it '親の説明が英語のままの場合は流用しない' do
+      english_parent = ExternalApis::BaseAdapter::SearchResult.new(
+        '進撃の巨人', 'anime', 'A massive series of giants threatening humanity.',
+        nil, 25, '1', 'anilist', { popularity: 1.0 }
+      )
+      allow(anilist_double).to receive(:safe_search).and_return([english_parent, season2_english])
+      results = service.search('進撃の巨人', media_type: 'anime')
+      season2 = results.find { |r| r.title == '進撃の巨人 Season 2' }
+      expect(season2.description).to eq('Eren Jaeger swore to wipe out every last Titan.')
+      expect(season2.metadata[:description_from_parent]).to be_nil
+    end
+
+    it '既に日本語説明を持つ子（Season 3 等）は流用しない' do
+      season3_japanese = ExternalApis::BaseAdapter::SearchResult.new(
+        '進撃の巨人 Season 3', 'anime', '母親の命を奪った巨人を駆逐するため戦う。',
+        nil, 22, '5', 'anilist', { popularity: 0.85 }
+      )
+      allow(anilist_double).to receive(:safe_search).and_return([parent_with_japanese, season3_japanese])
+      results = service.search('進撃の巨人', media_type: 'anime')
+      season3 = results.find { |r| r.title == '進撃の巨人 Season 3' }
+      # 既存の日本語説明が保持される
+      expect(season3.description).to eq('母親の命を奪った巨人を駆逐するため戦う。')
+      expect(season3.metadata[:description_from_parent]).to be_nil
+    end
+  end
+
   describe 'キャッシュ' do
     # キャッシュ動作テストではメモリストアを使用（test環境のデフォルトは:null_store）
     around do |example|
@@ -520,7 +616,7 @@ RSpec.describe WorkSearchService, type: :service do
       Rails.cache.write('work_search:anime:テスト', [mock_result])
       # 新しい検索は新しいキー形式で保存される
       service.search('テスト', media_type: 'anime')
-      expect(Rails.cache.exist?('work_search:v2:anime:テスト')).to be true
+      expect(Rails.cache.exist?('work_search:v3:anime:テスト')).to be true
     end
   end
 end

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -198,6 +198,57 @@ RSpec.describe WorkSearchService, type: :service do
     end
   end
 
+  describe '#search 品質込みソート' do # rubocop:disable RSpec/MultipleMemoizedHelpers
+    let(:full_result) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '作品A', 'anime', '説明あり', 'https://img.jpg', nil,
+        '1', 'anilist', { popularity: 0.3 }
+      )
+    end
+    let(:image_only) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '作品B', 'anime', nil, 'https://img.jpg', nil,
+        '2', 'anilist', { popularity: 0.9 }
+      )
+    end
+    let(:desc_only) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '作品C', 'anime', '説明あり', nil, nil,
+        '3', 'anilist', { popularity: 0.9 }
+      )
+    end
+    let(:empty_result) do
+      ExternalApis::BaseAdapter::SearchResult.new(
+        '作品D', 'anime', nil, nil, nil,
+        '4', 'anilist', { popularity: 1.0 }
+      )
+    end
+
+    before do
+      allow(anilist_double).to receive(:safe_search).and_return(
+        [empty_result, image_only, desc_only, full_result]
+      )
+      # 補完をバイパスするため Wikipedia/TMDB をスタブ
+      wiki = instance_double(ExternalApis::WikipediaClient, search_and_fetch_extract: nil)
+      allow(ExternalApis::WikipediaClient).to receive(:new).and_return(wiki)
+      allow(tmdb_double).to receive(:fetch_japanese_description).and_return(nil)
+    end
+
+    it '画像+説明ありを最上位、両方なしを最下位に並べる' do
+      results = service.search('テスト', media_type: 'anime')
+      expect(results.first.title).to eq('作品A') # 画像+説明あり
+      expect(results.last.title).to eq('作品D')  # 両方なし
+    end
+
+    it '同じ品質レベル内では人気度順に並ぶ' do
+      results = service.search('テスト', media_type: 'anime')
+      # 画像のみ(popularity=0.9)と説明のみ(popularity=0.9) は同じ品質スコア0.5
+      # popularity が同じなので順序は保証されないが、両方がAの後に来る
+      mid_titles = [results[1].title, results[2].title]
+      expect(mid_titles).to contain_exactly('作品B', '作品C')
+    end
+  end
+
   describe '英語説明の保持' do
     # Task 6 以降: 破壊的な remove_english_descriptions を廃止し、
     # Wikipedia/TMDBで日本語説明が取れなかった場合は英語をそのまま残す方針に変更した

--- a/docs/superpowers/plans/2026-04-12-search-quality-improvement.md
+++ b/docs/superpowers/plans/2026-04-12-search-quality-improvement.md
@@ -342,7 +342,10 @@ module ExternalApis
   # APIキー不要・無料・ISBNベースで書誌情報と書影を提供する日本書籍データベース
   # WorkSearchService#enrich_books_via_openbd から使用される
   class OpenbdClient
-    BASE_URL = 'https://api.openbd.jp/v1'
+    # NOTE: Faradayは '/' 始まりのパスを渡されるとbase_urlのパス部を破棄する仕様。
+    # そのため BASE_URL にはホストのみを指定し、パスは ENDPOINT_PATH 側で持つ
+    BASE_URL = 'https://api.openbd.jp'
+    ENDPOINT_PATH = '/v1/get'
     USER_AGENT = 'Recolly/1.0 (https://github.com/IKcoding-jp/Recolly)'
 
     # ISBN から書誌データを取得する
@@ -350,7 +353,7 @@ module ExternalApis
     def fetch(isbn)
       return nil if isbn.blank?
 
-      response = connection.get('/get', { isbn: isbn })
+      response = connection.get(ENDPOINT_PATH, { isbn: isbn })
       data = response.body&.first
       return nil if data.nil?
 

--- a/frontend/src/components/WorkCard/WorkCard.module.css
+++ b/frontend/src/components/WorkCard/WorkCard.module.css
@@ -68,6 +68,16 @@
   margin: 0;
 }
 
+/* シリーズ子作品（Season 2 等）で親の日本語説明を流用した際の注釈ラベル */
+/* description の上に小さく表示し、ユーザーに「シーズン固有ではなく全体概要」と伝える */
+.parentDescriptionNote {
+  display: block;
+  font-family: var(--font-body);
+  font-size: var(--font-size-meta);
+  color: var(--color-text-muted);
+  margin-bottom: var(--spacing-xs);
+}
+
 .description {
   font-family: var(--font-body);
   font-size: var(--font-size-meta);

--- a/frontend/src/components/WorkCard/WorkCard.test.tsx
+++ b/frontend/src/components/WorkCard/WorkCard.test.tsx
@@ -62,4 +62,34 @@ describe('WorkCard', () => {
     const action = container.querySelector('[class*="action"]')
     expect(action?.textContent).toBe('記録済み')
   })
+
+  it('metadata.description_from_parent が true の時に注釈を表示する', () => {
+    const work: SearchResult = {
+      title: '進撃の巨人 Season 2',
+      media_type: 'anime',
+      description: '繁栄を築き上げた人類は...',
+      cover_image_url: null,
+      total_episodes: 12,
+      external_api_id: '2',
+      external_api_source: 'anilist',
+      metadata: { description_from_parent: true },
+    }
+    render(<WorkCard work={work} onRecord={vi.fn()} />)
+    expect(screen.getByText('※ シリーズ全体の説明')).toBeInTheDocument()
+  })
+
+  it('metadata.description_from_parent が undefined の時は注釈を表示しない', () => {
+    const work: SearchResult = {
+      title: '進撃の巨人',
+      media_type: 'anime',
+      description: '繁栄を築き上げた人類は...',
+      cover_image_url: null,
+      total_episodes: 25,
+      external_api_id: '1',
+      external_api_source: 'anilist',
+      metadata: {},
+    }
+    render(<WorkCard work={work} onRecord={vi.fn()} />)
+    expect(screen.queryByText('※ シリーズ全体の説明')).not.toBeInTheDocument()
+  })
 })

--- a/frontend/src/components/WorkCard/WorkCard.tsx
+++ b/frontend/src/components/WorkCard/WorkCard.tsx
@@ -43,7 +43,14 @@ export function WorkCard({ work, onRecord, isRecorded = false, isLoading = false
           {MEDIA_TYPE_LABELS[work.media_type]}
         </span>
         <h3 className={styles.title}>{work.title}</h3>
-        {work.description && <p className={styles.description}>{work.description}</p>}
+        {work.description && (
+          <>
+            {work.metadata?.description_from_parent === true && (
+              <span className={styles.parentDescriptionNote}>※ シリーズ全体の説明</span>
+            )}
+            <p className={styles.description}>{work.description}</p>
+          </>
+        )}
       </div>
       <div className={styles.action}>
         {isRecorded ? (

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -44,6 +44,8 @@ export interface WorkMetadata {
   popularity?: number
   title_english?: string
   title_romaji?: string
+  // シリーズ作品（Season 2等）で、親作品の日本語説明を流用したことを示すフラグ
+  description_from_parent?: boolean
   [key: string]: unknown
 }
 

--- a/frontend/src/lib/worksApi.ts
+++ b/frontend/src/lib/worksApi.ts
@@ -2,10 +2,17 @@ import type { SearchResponse, WorkResponse, MediaType } from './types'
 import { request } from './api'
 
 export const worksApi = {
-  search(query: string, mediaType?: MediaType): Promise<SearchResponse> {
+  // options.signal で AbortController と連携できるようにする（検索のレース条件対策）
+  search(
+    query: string,
+    mediaType?: MediaType,
+    options?: { signal?: AbortSignal },
+  ): Promise<SearchResponse> {
     const params = new URLSearchParams({ q: query })
     if (mediaType) params.append('media_type', mediaType)
-    return request<SearchResponse>(`/works/search?${params.toString()}`)
+    return request<SearchResponse>(`/works/search?${params.toString()}`, {
+      signal: options?.signal,
+    })
   },
 
   create(title: string, mediaType: MediaType, description?: string): Promise<WorkResponse> {

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -313,4 +313,138 @@ describe('SearchPage', () => {
     // プログレスバーが表示される
     expect(screen.getByRole('progressbar')).toBeInTheDocument()
   })
+
+  it('新しい検索を開始したら、前の結果が即座に消える', async () => {
+    const user = userEvent.setup()
+    // 1回目の検索（成功）
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              title: '人間失格',
+              media_type: 'book',
+              description: '古い結果',
+              cover_image_url: null,
+              total_episodes: null,
+              external_api_id: '1',
+              external_api_source: 'google_books',
+              metadata: {},
+            },
+          ],
+        }),
+    })
+
+    renderSearchPage()
+    const input = await screen.findByPlaceholderText('作品を検索...')
+    await user.type(input, '人間失格')
+    await user.click(screen.getByRole('button', { name: /検索/ }))
+
+    // 1回目の結果が表示される
+    await waitFor(() => {
+      expect(screen.getByText('人間失格')).toBeInTheDocument()
+    })
+
+    // 2回目の検索（APIは永久保留、即時クリアを確認するため）
+    let resolveSecond: ((value: unknown) => void) | null = null
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecond = resolve
+        }),
+    )
+
+    await user.clear(input)
+    await user.type(input, 'ワンピース')
+    await user.click(screen.getByRole('button', { name: /検索/ }))
+
+    // 2回目のレスポンスが返る前に、1回目の結果が画面から消えている
+    await waitFor(() => {
+      expect(screen.queryByText('古い結果')).not.toBeInTheDocument()
+    })
+
+    // クリーンアップ
+    resolveSecond?.({
+      ok: true,
+      json: () => Promise.resolve({ results: [] }),
+    })
+  })
+
+  it('検索中にさらに別の検索を開始すると、古いリクエストの結果は反映されない', async () => {
+    const user = userEvent.setup()
+    // 1回目の検索を意図的に遅延させる
+    let resolveFirst: ((value: unknown) => void) | null = null
+    mockFetch.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        }),
+    )
+    // 2回目の検索は即座に返る
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              title: 'ワンピース新結果',
+              media_type: 'manga',
+              description: '新しい結果',
+              cover_image_url: null,
+              total_episodes: null,
+              external_api_id: '2',
+              external_api_source: 'anilist',
+              metadata: {},
+            },
+          ],
+        }),
+    })
+
+    renderSearchPage()
+    const input = await screen.findByPlaceholderText('作品を検索...')
+    await user.type(input, '古い検索')
+    await user.click(screen.getByRole('button', { name: /検索/ }))
+
+    // 2回目の検索を直後に投げる
+    // 1回目の検索が永久保留のため検索ボタンが disabled のままになる。
+    // userEvent.click は disabled 要素では発火しないので、フォーム送信を直接 dispatch して
+    // handleSearch を呼ぶ（実アプリでも検索中の再送信は disabled で防がれるが、
+    // ここではレース条件のロジックそのものを検証したい）。
+    await user.clear(input)
+    await user.type(input, '新しい検索')
+    const form = input.closest('form')
+    if (!form) throw new Error('form not found')
+    fireEvent.submit(form)
+
+    // 2回目の結果が画面に表示される
+    await waitFor(() => {
+      expect(screen.getByText('ワンピース新結果')).toBeInTheDocument()
+    })
+
+    // 遅延していた1回目のレスポンスが遅れて返ってくる
+    resolveFirst?.({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              title: '遅延した古い結果',
+              media_type: 'book',
+              description: '古い',
+              cover_image_url: null,
+              total_episodes: null,
+              external_api_id: '99',
+              external_api_source: 'google_books',
+              metadata: {},
+            },
+          ],
+        }),
+    })
+
+    // 古い結果は画面に現れない（AbortControllerで中断されているため）
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    expect(screen.queryByText('遅延した古い結果')).not.toBeInTheDocument()
+    expect(screen.getByText('ワンピース新結果')).toBeInTheDocument()
+  })
 })

--- a/frontend/src/pages/SearchPage/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { FormEvent } from 'react'
 import type { SearchResult, MediaType, RecordStatus } from '../../lib/types'
 import { worksApi } from '../../lib/worksApi'
@@ -51,6 +51,10 @@ export function SearchPage() {
   // 手動登録で作成したWorkのID（Record作成時に使用）
   const [manualWorkId, setManualWorkId] = useState<number | null>(null)
 
+  // 検索リクエストのキャンセル用 AbortController を保持する
+  // 新しい検索が開始されたら古いリクエストを中断する
+  const abortControllerRef = useRef<AbortController | null>(null)
+
   // マウント時にユーザーの記録済み作品IDリストを取得
   useEffect(() => {
     recordsApi
@@ -65,22 +69,36 @@ export function SearchPage() {
     e.preventDefault()
     if (!query.trim()) return
 
+    // 古いリクエストがあればキャンセルする
+    abortControllerRef.current?.abort()
+    const controller = new AbortController()
+    abortControllerRef.current = controller
+
+    // 画面上の古い結果を即座にクリア
+    setResults([])
     setIsSearching(true)
     setError('')
     setHasSearched(true)
 
     try {
       const mediaType = genre === 'all' ? undefined : genre
-      const response = await worksApi.search(query, mediaType)
+      const response = await worksApi.search(query, mediaType, { signal: controller.signal })
+      // このリクエストがキャンセルされていたら結果を反映しない
+      if (controller.signal.aborted) return
       setResults(response.results)
     } catch (err) {
+      // AbortError（ユーザー/システムが中断した）は無視する
+      if ((err as Error).name === 'AbortError') return
       if (err instanceof ApiError) {
         setError(err.message)
       } else {
         setError('検索に失敗しました')
       }
     } finally {
-      setIsSearching(false)
+      // キャンセルされていない場合のみローディングを解除
+      if (!controller.signal.aborted) {
+        setIsSearching(false)
+      }
     }
   }
 
@@ -160,14 +178,30 @@ export function SearchPage() {
   const handleGenreChange = (newGenre: GenreFilter) => {
     setGenre(newGenre)
     if (query.trim() && hasSearched) {
+      abortControllerRef.current?.abort()
+      const controller = new AbortController()
+      abortControllerRef.current = controller
+
+      setResults([])
       setIsSearching(true)
       setError('')
+
       const mediaType = newGenre === 'all' ? undefined : newGenre
       worksApi
-        .search(query, mediaType)
-        .then((response) => setResults(response.results))
-        .catch(() => setError('検索に失敗しました'))
-        .finally(() => setIsSearching(false))
+        .search(query, mediaType, { signal: controller.signal })
+        .then((response) => {
+          if (controller.signal.aborted) return
+          setResults(response.results)
+        })
+        .catch((err: Error) => {
+          if (err.name === 'AbortError') return
+          setError('検索に失敗しました')
+        })
+        .finally(() => {
+          if (!controller.signal.aborted) {
+            setIsSearching(false)
+          }
+        })
     }
   }
 


### PR DESCRIPTION
## Summary

Issue #127 の検索品質改善を実装。仕様書ベース（PR #128）の上に 17 コミットで以下を実装した。

- **補完強化**: 全ソース対象の説明文補完、openBD による書籍補完、Wikipedia 検索の2段階化
- **品質ソート**: 画像・説明欠損を下位に押し下げる品質スコアソート
- **キャンセル制御**: SearchPage の AbortController + 結果即時クリアでレース条件解消
- **シリーズ流用**: シリーズ作品（Season N, OVA, 完結編 等）に親作品の日本語説明を流用
- **誤マッチ防止**: TitleMatcher と境界文字判定で「進撃の巨人ファンクラブ」型の誤マッチを排除

## 主な変更

### バックエンド

| Task | 変更 | 主な追加/変更 |
|---|---|---|
| 1 | キャッシュバージョニング | \`CACHE_VERSION = 'v4'\` |
| 2 | GoogleBooksAdapter 強化 | metadata に ISBN 含める |
| 3 | OpenbdClient 新規 | ISBN ベースで日本書籍補完 |
| 4 | WikipediaClient 新規メソッド | \`search_and_fetch_extract\`（検索→取得2段階）|
| 5 | WorkSearchService 補完 | \`enrich_books_via_openbd\`（並列スレッド）|
| 6 | 補完ロジック書き換え | \`enrich_missing_descriptions\`（全ソース対象）|
| 7 | 品質ソート | \`sort_by_quality_and_popularity\`（画像+説明スコア）|
| 11 | TitleMatcher 新規 | NFKC 正規化 + 完全一致で誤マッチ防止 |
| 12 | シリーズ親流用 | \`share_series_descriptions\`（プレフィックスマッチ + 境界判定）|

### フロントエンド

| Task | 変更 |
|---|---|
| 8 | \`worksApi.search\` に \`signal\` オプション追加 |
| 9 | \`SearchPage\` に \`AbortController\` + 結果即時クリア |
| 12 | \`WorkCard\` に「※ シリーズ全体の説明」注釈表示 |

## 実測結果（24タイトル / Playwright）

### 仕様書目標との比較

| 指標 | 目標 | 実測 | 結果 |
|---|---|---|---|
| 全体の説明なし率 | 25%以下 | **10.2%** (27/266) | ✅ |
| 漫画の説明なし率 | 30%以下 | **6.1%** (7/114) | ✅ |
| ゲームの説明なし率 | 30%以下 | **0%** (0/43) | ✅ |
| 本の画像なし率 | 10%以下 | 25% (12/48) | ⚠️ 構造的限界 |

### 構造的限界の説明

「本の画像なし率 25%」未達の 12 件はすべて以下の特殊ケース:
- 6 件: 外国語版（フランス語、ドイツ語、スウェーデン語版オリジナル等）→ 日本書籍流通DB の openBD では補完不可
- 3 件: ISBN なし（電子書籍版・古い版）→ openBD は ISBN ベースのため呼べない
- 2 件: 特装版・合本（ISBN あるが openBD カバレッジ外）
- 1 件: 普通版で openBD が取れず

**Task 7 の品質ソートにより、画像欠損は下位に押し下げられる**ため、ユーザーが目にする上位 5 件で見ると **5.6%** (1/18) で目標達成。

### シリーズ親流用効果（Task 12）

55 件のシリーズ作品が親由来の日本語説明で表示:
- 進撃の巨人 Season 2/3/Final Season/Part 2/完結編 前編・後編/外伝
- Re:ゼロ 2nd Season/Part 2/3rd season/OVAs
- HUNTER×HUNTER (2011)/Greed Island/G・I Final/パイロット版
- シュタインズ・ゲート 横行跋扈/境界面上/結晶多形

UI 上で「※ シリーズ全体の説明」と注釈表示。

### 連続検索のレース条件（Task 8/9）

AbortController で古いリクエストを中断し、新検索時に結果を即時クリア。E2E テストで遅延した古いレスポンスが新しい結果を上書きしないことを確認。

## Test Plan

- [x] バックエンド全テスト: **614/614 PASS**
- [x] フロントエンド全テスト: **465/465 PASS**
- [x] RuboCop (133 files): no offenses
- [x] ESLint: clean
- [x] Playwright で 24 タイトル実測 → 主要 3 目標達成
- [x] Playwright で進撃の巨人検索 → シリーズ親流用 + 注釈表示を視覚確認
- [x] シュタインズ・ゲート / Re:ゼロ / HUNTER×HUNTER で誤マッチ・正当流用の両方を確認

## 既知の制約

- **本の画像なし率 25%** は openBD の構造的限界（外国語版・特殊版・電子版に画像なし）。品質ソートで上位に来ないため UX 影響は最小化。
- **`npm run build` の TS エラー 6 件**（RecordListItem / RecommendationsPage / SearchPage の `rating: number | null` 型問題、vite.config.ts の test 型問題）は本 PR で触っていない main 由来の既存債務。別 PR で対処予定。

## 関連

- Closes #127
- Depends on #128 (docs PR)
- ADR-0038: 検索品質改善アプローチに C-2 を採用
- ADR-0039: 書籍データ補完 API に openBD を採用

🤖 Generated with [Claude Code](https://claude.com/claude-code)