### PR TITLE
fix(frontend): main から持ち越された TypeScript 型エラー 4 件を修正 + CI に型チェックを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run format:check
+      - run: npm run typecheck
 
   frontend-test:
     name: Frontend Test

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
+    "typecheck": "tsc -b --noEmit",
     "format": "prettier --write 'src/**/*.{ts,tsx,css,json}'",
     "format:check": "prettier --check 'src/**/*.{ts,tsx,css,json}'",
     "preview": "vite preview",

--- a/frontend/src/components/RecordListItem/RecordListItem.tsx
+++ b/frontend/src/components/RecordListItem/RecordListItem.tsx
@@ -10,12 +10,15 @@ type RecordListItemProps = {
 export function RecordListItem({ record }: RecordListItemProps) {
   const { work } = record
   const hasRating = record.rating !== null
-  const hasEpisodes = work.total_episodes !== null
+  // ローカル const を経由することで TypeScript の型 narrowing が効くようにする
+  // （オブジェクトのプロパティアクセスは narrowing されないため）
+  const totalEpisodes = work.total_episodes
+  const hasEpisodes = totalEpisodes !== null
 
   // 進捗の割合を計算（プログレスバー描画用）
   const progressPercent =
-    hasEpisodes && work.total_episodes > 0
-      ? Math.min((record.current_episode / work.total_episodes) * 100, 100)
+    totalEpisodes !== null && totalEpisodes > 0
+      ? Math.min((record.current_episode / totalEpisodes) * 100, 100)
       : 0
 
   return (

--- a/frontend/src/lib/recordsApi.ts
+++ b/frontend/src/lib/recordsApi.ts
@@ -3,7 +3,9 @@ import { request } from './api'
 
 type RecordCreateOptions = {
   status?: RecordStatus
-  rating?: number
+  // rating は「未設定」を null として明示的にバックエンドに送る契約のため null を許容する
+  // （テスト: SearchPage.test.tsx の「連続で異なる作品を記録する」が request body の rating を null で検証）
+  rating?: number | null
 }
 
 type RecordUpdateParams = {

--- a/frontend/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -41,6 +41,8 @@ export function RecommendationsPage() {
           media_type: modalWork.media_type as MediaType,
           description: modalWork.description,
           cover_image_url: modalWork.cover_url,
+          // RecommendedWork は総話数情報を持たないため null を明示的に設定
+          total_episodes: null,
           external_api_id: modalWork.external_api_id,
           external_api_source: modalWork.external_api_source,
           metadata: modalWork.metadata,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,5 +1,5 @@
-/// <reference types="vitest" />
-import { defineConfig } from 'vite'
+// Vitest の test 設定を含む型を使うため、'vite' ではなく 'vitest/config' から import する
+import { defineConfig } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 import { VitePWA } from 'vite-plugin-pwa'
 


### PR DESCRIPTION
## Summary

- \`npm run build\`（= \`tsc -b && vite build\`）で発生していた TypeScript 型エラー **4 件（計 6 行分）** を修正
- 再発防止のため **CI に型チェックステップを追加**（Option B: \`npx tsc -b --noEmit\`、IK さんの判断）

## 背景

PR #130 の Task 1 で \`npx vite build\` 採用時に判明した事実：
- \`npm run build\` が **main ブランチで既に失敗していた**
- CI は lint と test のみで型チェックを走らせていなかった
- CD も \`vite build\` 単体で \`tsc -b\` を含まず、型エラーが検出されない設計だった
- 本番デプロイは \`vite build\` のみで動いているため、本番影響はゼロ

Issue #135 でこれを解消します。

## 型エラー 4 件の修正

### 1. RecordListItem.tsx:17-18 (TS18047)

オブジェクトプロパティアクセス（\`work.total_episodes\`）では TypeScript の型 narrowing が
効かないため、ローカル const \`totalEpisodes\` を経由して narrowing を効かせる。

\`\`\`tsx
// Before
const hasEpisodes = work.total_episodes !== null
const progressPercent =
  hasEpisodes && work.total_episodes > 0  // ← narrowing が効かずエラー
    ? Math.min((record.current_episode / work.total_episodes) * 100, 100)
    : 0

// After
const totalEpisodes = work.total_episodes
const hasEpisodes = totalEpisodes !== null
const progressPercent =
  totalEpisodes !== null && totalEpisodes > 0  // ← ローカル const なら narrowing が効く
    ? Math.min((record.current_episode / totalEpisodes) * 100, 100)
    : 0
\`\`\`

### 2. RecommendationsPage.tsx:39 (TS2345)

\`RecommendedWork\` 型は \`total_episodes\` フィールドを持たないため、
\`createFromSearchResult\` に渡す workData に \`total_episodes: null\` を明示的に追加。

### 3. recordsApi.ts: RecordCreateOptions.rating の型修正（←重要な発見）

**TypeScript の型と runtime の契約が食い違っていた**ことを発見：
- 型: \`rating?: number\`（= \`number | undefined\`）
- 実際: \`SearchPage.test.tsx\` が **request body の rating が \`null\` であること**を検証していた

つまり型が嘘をついていた状態。型を \`number | null\` に変更して現実に合わせました。

**この発見は重要**：初回の修正で \`?? undefined\` による型変換を試したら、
既存テストが 1 件失敗しました（\"expected undefined to be null\"）。これにより
「型エラーを表面的に消す修正」と「根本原因に基づく修正」の違いを明確に区別できました。

結果として \`SearchPage.tsx\` と \`RecommendationsPage.tsx\` の呼び出し側は
変更不要になり、\`recordData\` をそのまま API に渡せるようになりました。

### 4. vite.config.ts:65 (TS2769)

\`import { defineConfig } from 'vite'\` では \`test\` プロパティを認識しないため、
\`vitest/config\` の \`defineConfig\` に変更。\`/// <reference types=\"vitest\" />\` は
不要になったため削除。

\`\`\`ts
// Before
/// <reference types=\"vitest\" />
import { defineConfig } from 'vite'

// After
import { defineConfig } from 'vitest/config'
\`\`\`

## CI への型チェック追加（Option B）

### IK さんの判断
Issue 本文の 3 つの選択肢（A: npm run build、B: tsc -b --noEmit、C: build スクリプト変更）から **Option B** を選択。理由：型チェックのみで高速（数秒）、今回の 4 件のエラーを全て検出できる。

### Issue の Option B のコマンドを訂正
Issue 本文では \`npx tsc --noEmit\` と書かれていましたが、**このコマンドは Recolly では動作しません**。
\`frontend/tsconfig.json\` が \`\"files\": []\` + references 構成のため、\`tsc --noEmit\` だと
何もチェックせずに exit 0 で終わります。正しくは **\`tsc -b --noEmit\`**（プロジェクト参照を解決）。

### 実装

**1. \`frontend/package.json\` に \`typecheck\` スクリプト追加:**

\`\`\`json
\"typecheck\": \"tsc -b --noEmit\"
\`\`\`

ローカルでも \`npm run typecheck\` で型チェックできるようになります。

**2. \`.github/workflows/ci.yml\` の \`frontend-lint\` ジョブにステップ追加:**

\`\`\`yaml
- run: npm ci
- run: npm run lint
- run: npm run format:check
- run: npm run typecheck   # ← 追加
\`\`\`

型チェックは静的解析の一種なので \`frontend-lint\` に配置（\`frontend-test\` ではなく）。

## 受け入れ条件（Issue #135）

- [x] \`cd frontend && npx tsc -b --noEmit\` が exit 0 になる（= \`npm run typecheck\` 成功）
- [x] \`cd frontend && npm run build\` が成功する
- [x] 既存テスト全てパス（466 tests / 69 files）
- [x] CI への型チェック追加方針が決まっている（**Option B で追加**）

## Test plan

- [x] Vitest: 466 tests pass
- [x] ESLint: 0 errors
- [x] \`npm run build\`: 成功（型チェック + ビルド両方パス）
- [x] \`npm run typecheck\`: exit 0
- [ ] このマージ後、CI の frontend-lint ジョブに新ステップが走ることを確認

## 関連

- Closes #135
- PR #130（Task 1 で発見）
- ADR-0040

🤖 Generated with [Claude Code](https://claude.com/claude-code)