### PR TITLE
docs(analytics): PostHog 導入の spec と ADR を追加

### DIFF
--- a/docs/adr/0041-プロダクト分析ツールにposthogを採用.md
+++ b/docs/adr/0041-プロダクト分析ツールにposthogを採用.md
@@ -1,0 +1,184 @@
+# ADR-0041: プロダクト分析ツールに PostHog を採用
+
+## ステータス
+承認済み
+
+## 背景
+Recolly はフェーズ 0〜4 の機能開発を終え、フェーズ 5 「マーケティング & マネタイズ」
+に入った。`docs/product-marketing-context.md` で定義したマーケ指標（登録ユーザー数、
+記録件数、**ジャンル横断率**、継続率、DAU/WAU/MAU）を実データで計測するための基盤が
+必要になった。
+
+現状、Recolly には計測ツールが一切入っていない（`frontend/index.html` には
+Google Identity Services の OAuth 用スクリプトしか無く、バックエンドにも計測用 gem は
+存在しない）。
+
+この段階でプロダクト分析ツールを選定し、マーケ判断・施策評価の土台を作る。
+
+## 選択肢
+
+### A案: GA4（Google Analytics 4）
+- **これは何か:** Google の公式 Web 分析ツール。世界で最も使われている。無料。
+  pageview ベースのトラフィック分析が主目的。
+- **長所:**
+  - 完全無料
+  - 業界標準。知名度が高く、面接や履歴書での通用性が高い
+  - Google 広告との連携がスムーズ
+  - BigQuery エクスポート機能
+- **短所:**
+  - UI が複雑で学習コストが重い
+  - プロダクト分析（リテンション、カスタム指標、ファネル）は苦手
+  - カスタム指標の実装が冗長（4 階層のパラメータ設定が必要）
+  - EU では Cookie 同意バナーが事実上必須
+  - データのサンプリングが発生する
+
+### B案: PostHog
+- **これは何か:** オープンソースのプロダクト分析ツール。イベントベース。
+  React 用 SDK (`posthog-js`) があり、無料枠が広い（100 万イベント/月）。
+  セルフホストも可能。
+- **長所:**
+  - プロダクト分析が本業。リテンション・ファネル・カスタム指標の導出が素直
+  - React SDK が使いやすく `posthog.capture('event', props)` で発火できる
+  - 無料枠が 100 万イベント/月と広い（個人開発では事実上無制限）
+  - 「ジャンル横断率」のようなカスタム指標が Insight として定義しやすい
+  - Cookie 同意バナーを避けた運用が可能（identify 前は匿名、identify で紐付け）
+  - セッション録画・機能フラグ・A/B テストも同一プロダクトに統合されている
+- **短所:**
+  - 知名度は GA4 に劣る（面接では説明が必要）
+  - アカウント登録が必要
+  - 日本語ドキュメントが少ない
+
+### C案: Plausible / Umami
+- **これは何か:** プライバシー重視のシンプルな計測ツール。Cookie を使わず
+  個人特定もしない。pageview 計測が中心。
+- **長所:**
+  - Cookie 同意バナー不要
+  - UI がシンプル
+  - プライバシー対応が完璧（GDPR/APPI ノータッチ）
+  - Umami はオープンソースで自前ホスティング可
+- **短所:**
+  - イベント計測・リテンション分析が弱い
+  - カスタム指標の表現力が低い
+  - Plausible は有料（$9/月〜）
+  - ファネル分析ができない
+  - 目的である「ジャンル横断率」の計測が実質不可能
+
+### D案: Mixpanel / Amplitude
+- **これは何か:** 大規模 SaaS 向けのプロダクト分析ツール。イベントベースで
+  高度なコホート分析・ファネル分析ができる。
+- **長所:**
+  - プロダクト分析の表現力が最強
+  - 大規模企業での採用実績が豊富
+- **短所:**
+  - 無料枠が狭い（Mixpanel: 10 万 MTU、Amplitude: 5 万 MTU）
+  - 個人開発では過剰スペック
+  - 実装の学習コストも重い
+
+### E案: GA4 + PostHog 併用
+- **これは何か:** GA4 でトラフィック分析・広告アトリビューション、PostHog で
+  プロダクト分析を行う 2 ツール構成。
+- **長所:**
+  - 両ツールの良いところ取り
+  - 広告運用を始める段階で GA4 の恩恵を受けられる
+- **短所:**
+  - 実装コストが 2 倍
+  - 個人開発・初期段階では過剰
+  - ユーザー体験に Cookie 同意バナーが必要になる（GA4 側の都合）
+
+## 決定
+**B案: PostHog を採用する。**
+
+スコープは Phase 1 の 4 イベント（`$pageview`, `$identify`, `signup_completed`,
+`record_created`）に限定する。Phase 2 以降の詳細イベントは運用開始後に追加する。
+
+詳細な実装設計は
+`docs/superpowers/specs/2026-04-13-analytics-tracking-design.md`
+を参照。
+
+## 理由
+
+- **計測目的との整合性**: Recolly が必要としている指標（ジャンル横断率、
+  継続率、DAU/WAU/MAU、登録→初回記録ファネル）はすべてプロダクト分析の
+  得意領域。GA4 で同じことをやろうとすると実装が冗長で運用が重い。
+
+- **A 案（GA4）を選ばなかった理由**: UI の複雑さとプロダクト分析の弱さ。
+  「ジャンル横断率」のようなカスタム指標を定義するには GA4 では
+  カスタムディメンション + 探索レポート + セグメントを組み合わせる必要があり、
+  個人開発者にとって運用コストが高すぎる。面接受けは良いが、実用性で不利。
+
+- **C 案（Plausible/Umami）を選ばなかった理由**: 機能不足。
+  Recolly の差別化点である「ジャンル横断率」を計測できないなら、
+  計測基盤として成立しない。
+
+- **D 案（Mixpanel/Amplitude）を選ばなかった理由**: 無料枠が狭すぎる。
+  Recolly の規模感では PostHog の無料枠で必要十分。
+
+- **E 案（併用）を選ばなかった理由**: 実装コスト 2 倍の見返りが現段階では
+  見合わない。広告運用を本格化するフェーズで再検討する。
+
+- **プライバシー対応の相性**: PostHog は identify 前は匿名でイベント収集でき、
+  日本の APPI 対応として「プライバシーポリシー提示 + 自動計測」のアプローチと
+  相性が良い（`docs/product-marketing-context.md` の方針と一致）。
+
+- **将来の拡張余地**: PostHog はセッション録画・機能フラグ・A/B テスト・
+  サーベイ機能まで統合されており、マーケ施策が進むにつれて活用範囲を
+  広げられる。
+
+## 影響
+
+### コードベース
+- `frontend/package.json` に `posthog-js` を追加
+- `frontend/src/lib/analytics/` を新設（`posthog.ts`, `events.ts`, テスト）
+- `frontend/src/main.tsx` で PostHog を初期化
+- `frontend/src/contexts/AuthContext.tsx`（または `useAuth`）で
+  ログイン時に `identify`、ログアウト時に `reset`
+- `frontend/src/pages/SignUpPage/SignUpPage.tsx` で `signup_completed` を発火
+- 記録作成のフック（`useRecordCreate` 等）で `record_created` を発火
+- `App.tsx` 内で React Router の location 変化時に `$pageview` を手動発火
+- `frontend/src/pages/PrivacyPage/` を新設してプライバシーポリシーを配置
+- フッターに `/privacy` へのリンクを追加
+
+### 環境変数
+- `VITE_POSTHOG_KEY`（Project API Key、公開 OK）
+- `VITE_POSTHOG_HOST`（`https://us.i.posthog.com`）
+- 開発: `frontend/.env.local`
+- 本番: AWS SSM Parameter Store → CI/CD ビルドステップで注入
+
+### プライバシー
+- 日本の APPI 対応として、Cookie 同意バナーは実装しない
+- プライバシーポリシーページ（`/privacy`）で計測内容を明記する
+- PII（メールアドレス、パスワード、感想本文、コメント本文、bio）は
+  PostHog に送信しない
+- EU からのアクセスには厳密な GDPR 対応は後回し（Recolly のターゲットが
+  日本中心のため）
+
+### パフォーマンス
+- `posthog-js` は非同期ロードされ、メインスレッドをブロックしない
+- 初期化失敗時も Recolly 本体は継続動作する
+- バンドルサイズ +約 40KB（gzipped）
+
+### 学習負荷
+- IK さんが新しく学ぶこと: PostHog の基本概念（イベント、プロパティ、
+  distinct_id、User Properties、Insight）、`posthog-js` の API
+- PostHog 導入後に学習ノート（`docs/learning/`）を作成することを推奨
+
+### テスト
+- `posthog-js` を `vi.mock('posthog-js')` でモックしてユニットテスト
+- 統合テストで主要イベント（`signup_completed`, `record_created`）の発火を検証
+- 手動検証: PostHog Live events ページで開発環境のイベント到達を確認
+
+### コスト
+- PostHog 無料枠（100 万イベント/月）内で運用。有料化の判断は
+  無料枠超過が見えた時点で別途検討する
+
+### 関連 ADR
+- ADR-0002（React + TypeScript 採用）— `posthog-js` の React SDK 経由で使用
+- ADR-0012（本番インフラに AWS フル構成 + Terraform 採用）— 本番環境の
+  環境変数は SSM Parameter Store で管理
+- ADR-0017（フロントエンド API クライアントに fetch + 独自ラッパー採用）—
+  PostHog SDK は本 API クライアントには干渉しない
+
+### 関連文書
+- `docs/product-marketing-context.md` — マーケ戦略の土台
+- `docs/superpowers/specs/2026-04-13-analytics-tracking-design.md` — 実装設計仕様
+- `docs/TODO.md` フェーズ 5「マーケティング & マネタイズ」

--- a/docs/superpowers/specs/2026-04-13-analytics-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-13-analytics-tracking-design.md
@@ -1,0 +1,275 @@
+# Analytics Tracking — 設計仕様書
+
+**作成日**: 2026-04-13
+**背景文書**: `docs/product-marketing-context.md`（フェーズ5: マーケティング & マネタイズ）
+
+---
+
+## 1. 概要
+
+### 1.1 目的
+
+Recolly にプロダクト分析基盤を導入し、マーケティング判断・施策評価に必要な定量データを取得できる状態にする。
+
+具体的には `docs/product-marketing-context.md` セクション 11 で定義した以下の指標を計測できるようにする：
+
+- 登録ユーザー数
+- 記録件数の累計
+- **ジャンル横断率**（2 ジャンル以上を記録するユーザー比率 = 差別化の動かぬ証拠）
+- 継続率（Day 1 / 7 / 30）
+- DAU / WAU / MAU
+
+### 1.2 選定ツール: **PostHog**
+
+`analytics-tracking` スキルでの検討の結果、以下の理由で PostHog を採用する：
+
+1. **プロダクト分析が本業**: Recolly が重要視する指標（リテンション、カスタム指標、ファネル）はプロダクト分析ツールの得意領域
+2. **無料枠が広い**: 100 万イベント/月（初期段階では十分）
+3. **実装が素直**: React 用 SDK (`posthog-js`) があり、`posthog.capture('event_name', { property: value })` で記録可能
+4. **カスタム指標に強い**: 「ジャンル横断率」のようなカスタム指標は PostHog の insight で定義しやすい
+5. **Cookie 同意バナーが不要な形で運用できる**: identify 前は匿名、identify 後にユーザーに紐付けというフローで日本の APPI に対応できる
+
+**採用しなかった選択肢**:
+
+| ツール | 不採用理由 |
+|---|---|
+| GA4 | UI 複雑、プロダクト分析（リテンション・ファネル）が苦手、カスタム指標の実装が重い |
+| Plausible / Umami | イベント計測・リテンション分析が弱い。pageview 中心すぎて目的に合わない |
+| Mixpanel / Amplitude | 有料枠が前提。個人開発では過剰 |
+| GA4 + PostHog 併用 | 個人開発では実装コスト 2 倍になり過剰 |
+
+### 1.3 スコープ
+
+本仕様は **Phase 1: MVP** のイベント 4 種類を対象とする。Phase 2・3 は本仕様の対象外（別仕様で扱う）。
+
+---
+
+## 2. 計測プラン
+
+### 2.1 イベント一覧（Phase 1）
+
+| # | イベント名 | 発火場所 | プロパティ | 目的 |
+|---|---|---|---|---|
+| 1 | `$pageview` | PostHog SDK 自動 | `$current_url`, `$referrer`（自動） | トラフィック分析 |
+| 2 | `signup_completed` | 新規登録成功時 | `method` (`email` / `google`) | 登録 CV |
+| 3 | `record_created` | 記録作成成功時 | `media_type` (`anime` / `movie` / `drama` / `book` / `manga` / `game`) | アクティベーション + **ジャンル横断率** |
+| 4 | `$identify` | ログイン成功時 | `distinct_id` = user_id、`$set`: `signup_method`, `signup_date` | 匿名ユーザーとログイン済みユーザーを紐付け、リテンション分析を可能にする |
+
+### 2.2 User Properties（identify 時に `$set` するプロパティ）
+
+| プロパティ名 | 値 | 由来 |
+|---|---|---|
+| `signup_method` | `email` / `google` | `User.provider` から取得 |
+| `signup_date` | ISO 8601 文字列 | `User.created_at` から取得 |
+
+### 2.3 計測できるようになる指標と導出方法
+
+| 指標 | 導出方法 |
+|---|---|
+| 登録ユーザー数 | `signup_completed` の unique user count |
+| 記録件数 | `record_created` の total count |
+| **ジャンル横断率** | `record_created` の `media_type` が distinct で 2 以上のユーザー / 全 identify 済みユーザー |
+| DAU / WAU / MAU | PostHog 自動（`$pageview` + `$identify` ベース） |
+| 継続率（Day 1/7/30） | PostHog 自動（retention insight） |
+| 登録 → 初回記録ファネル | `signup_completed` → `record_created` ファネル |
+
+### 2.4 Phase 2 以降（本仕様の対象外だが、意図を残す）
+
+Phase 2（V1 運用開始後に追加する）:
+- `search_performed`
+- `episode_progress_updated`
+- `record_status_changed`
+- `recommendation_clicked`
+
+Phase 3（必要になったら）:
+- `discussion_created`, `comment_posted`
+- `work_detail_viewed`
+- `library_filtered`
+- `tag_added`
+
+---
+
+## 3. 実装設計
+
+### 3.1 依存追加
+
+`frontend/package.json` に以下を追加する：
+
+```json
+{
+  "dependencies": {
+    "posthog-js": "^1.x"
+  }
+}
+```
+
+### 3.2 環境変数
+
+| 変数名 | 値 | 保存先 |
+|---|---|---|
+| `VITE_POSTHOG_KEY` | `phc_xxx` (Project API Key) | 開発: `.env.local`、本番: AWS SSM Parameter Store |
+| `VITE_POSTHOG_HOST` | `https://us.i.posthog.com` | 同上 |
+
+`.env.example` には両方のプレースホルダーを追加済み。
+
+### 3.3 モジュール構成
+
+```
+frontend/src/lib/analytics/
+├── posthog.ts           ← PostHog 初期化 + ラッパー API
+├── events.ts            ← イベント名の定数定義（tagged union 型）
+└── posthog.test.ts      ← ユニットテスト
+```
+
+### 3.4 `posthog.ts` の責務
+
+- 初期化（`posthog.init(key, { api_host })`）
+- 環境変数が未設定なら何もしない（ローカル環境でも起動を妨げない）
+- プライバシー設定: `capture_pageview: true`, `persistence: 'localStorage+cookie'`
+- 公開 API:
+  - `identify(user: User)` — ログイン成功時に呼ぶ
+  - `reset()` — ログアウト時に呼ぶ
+  - `capture(eventName, properties)` — イベント送信（薄いラッパー）
+  - `capturePageview()` — SPA の pageview を手動でトリガー（Vite + React Router 対応のため）
+
+### 3.5 イベント発火ポイントの改修
+
+| イベント | 発火ポイント | 改修対象ファイル |
+|---|---|---|
+| `$pageview` | React Router の location 変化時 | `frontend/src/App.tsx` または router 近辺 |
+| `$identify` | `useAuth` の login 成功時 | `frontend/src/contexts/AuthContext.tsx`（または `useAuth` の実装） |
+| `$reset` | `useAuth` の logout 成功時 | 同上 |
+| `signup_completed` | `SignUpPage` の登録成功時、および OAuth コールバック成功時 | `frontend/src/pages/SignUpPage/SignUpPage.tsx`、OAuth コールバック処理 |
+| `record_created` | 記録作成 API 成功レスポンス後 | 記録作成フック（`useRecordCreate` 等） |
+
+### 3.6 初期化タイミング
+
+`frontend/src/main.tsx` で `posthog.init()` を呼ぶ。ただし環境変数が未設定なら初期化しない（ローカル開発で空の `.env.local` でも動くように）。
+
+### 3.7 SPA の pageview ハンドリング
+
+PostHog の `capture_pageview: true` は初回ロードの pageview しか拾わない。React SPA の経路遷移は手動で `posthog.capture('$pageview')` する必要がある。
+
+実装方針:
+- `App.tsx` 内で `useLocation()` を監視し、location 変化時に `capturePageview()` を呼ぶ
+- 初回ロードは PostHog の init で自動発火される（重複しないように注意）
+
+---
+
+## 4. プライバシー対応
+
+### 4.1 方針: **プライバシーポリシー提示 + 自動計測**
+
+`product-marketing-context.md` での検討結果（選択肢 Y）に従う。
+
+- Cookie 同意バナーは表示しない
+- フッターに「プライバシーポリシー」ページへのリンクを追加
+- プライバシーポリシーページでは以下を明記:
+  - PostHog を使用していること
+  - 計測している内容（ログイン状態・操作イベント・PV）
+  - 匿名性を担保するために個人を特定できる情報（email 本文・パスワード・作品の感想本文等）は送信しないこと
+  - ユーザーが希望すれば計測を拒否できる方法（PostHog の opt-out）
+
+### 4.2 法的根拠
+
+- **日本（APPI）**: 個人情報の利用目的を公表すれば Cookie 同意バナーは不要。プライバシーポリシーで十分対応可能
+- **EU（GDPR）**: 厳密には Cookie 同意バナーが必要だが、Recolly のターゲットは日本中心のため許容範囲とする。EU ユーザーが主要ターゲットになった時点で consent mode を別途導入する
+
+### 4.3 PII を送信しない方針
+
+以下は PostHog に **送信しない**:
+
+- ユーザーのメールアドレス
+- パスワード
+- 作品の感想本文（`EpisodeReview.body`）
+- 掲示板のコメント本文
+- プロフィール bio
+
+以下は **送信する**:
+
+- ユーザー ID（distinct_id として）— これは内部 ID で PII ではない
+- `signup_method`, `signup_date`
+- `record_created` の `media_type`
+- 画面遷移の URL
+
+### 4.4 プライバシーポリシーページ
+
+- ルート: `/privacy`
+- 既存の共通コンポーネントを使用して作成
+- フッターからリンク
+
+---
+
+## 5. テスト
+
+### 5.1 ユニットテスト（Vitest）
+
+`frontend/src/lib/analytics/posthog.test.ts`:
+
+- 環境変数が未設定のとき、`init` が何もせず例外を投げない
+- 環境変数が設定されているとき、`posthog.init` が正しい引数で呼ばれる
+- `identify` が呼ばれたとき、`posthog.identify` に正しい引数が渡される
+- `reset` が呼ばれたとき、`posthog.reset` が呼ばれる
+- `capture` が薄いラッパーとして動作する
+
+モックは `vi.mock('posthog-js')` で置き換える。
+
+### 5.2 統合テスト
+
+- SignUpPage のテストで「登録成功時に `signup_completed` イベントが発火する」を検証
+- Login 成功時に `identify` が呼ばれることを検証
+
+### 5.3 手動検証
+
+- PostHog の Live events ページ（`https://us.posthog.com/project/{id}/events`）で開発環境のイベントがリアルタイムに届くか確認
+- `$identify` → ユーザーが PostHog の People ページに出現するか確認
+
+---
+
+## 6. 非機能要件
+
+### 6.1 パフォーマンス
+
+- PostHog SDK は非同期ロード（`posthog-js` のデフォルト）
+- メインスレッドをブロックしない
+- イベント送信失敗時に UI を止めない
+
+### 6.2 失敗時の振る舞い
+
+- PostHog の init / capture が失敗しても、Recolly 本体の機能は継続動作する
+- エラーはコンソールに警告ログを出すが、ユーザーには表示しない
+
+### 6.3 環境依存
+
+- **開発環境** (`.env.local`): IK 個人の PostHog プロジェクト
+- **本番環境** (AWS EC2): 同じ PostHog プロジェクトを使う
+  - 開発と本番でイベントを区別したい場合は PostHog の `properties.environment` で識別する（実装時に追加検討）
+
+---
+
+## 7. Out of Scope（本仕様では扱わない）
+
+- Phase 2 以降のイベント（`search_performed`, `episode_progress_updated` 等）
+- A/B テスト機能（PostHog 機能フラグ）
+- セッション録画機能
+- バックエンド（Rails）側のイベント発火（必要になったら別仕様）
+- EU GDPR 対応の Cookie consent banner
+- 既存ユーザーデータの PostHog への遡及インポート
+
+---
+
+## 8. 実装後のフォロー（別タスク）
+
+`docs/TODO.md` フェーズ5 に含まれる以下は本仕様の**対象外**だが、実装後に順次着手する：
+
+- 計測データを見るためのダッシュボード作成（PostHog の Dashboard 機能で insight を作成する）
+- イベントの定期レビュー（週次 or 月次）
+- Phase 2 イベント追加の別仕様書
+
+---
+
+## 9. 関連文書
+
+- 背景: `docs/product-marketing-context.md` セクション 11, 12
+- TODO: `docs/TODO.md` フェーズ5「マーケティング & マネタイズ」
+- ADR: `docs/adr/0041-プロダクト分析ツールにposthogを採用.md`

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,3 +2,13 @@
 # バックエンドの GOOGLE_CLIENT_ID と同じ値を設定する
 # 本番では CI/CD のビルドステップで注入する
 VITE_GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+
+# PostHog Product Analytics（フェーズ5: マーケ計測基盤）
+# PostHog プロジェクトの Project API Key（公開 OK・ブラウザに配布される）
+# 取得方法: https://us.posthog.com → Project Settings → Project API Key
+# 本番では CI/CD のビルドステップで SSM Parameter Store から注入する
+VITE_POSTHOG_KEY=phc_your-posthog-project-key
+# PostHog の API Host（リージョンによって異なる）
+# US Cloud: https://us.i.posthog.com
+# EU Cloud: https://eu.i.posthog.com
+VITE_POSTHOG_HOST=https://us.i.posthog.com


### PR DESCRIPTION
## Summary

- フェーズ5「マーケティング & マネタイズ」の計測基盤として PostHog を採用
- Phase 1 は最小 4 イベントに絞った設計
- 本 PR は spec / ADR / env.example のみ。実装は別 PR

## 背景

`docs/product-marketing-context.md` でマーケ指標（ジャンル横断率・継続率・
DAU/WAU/MAU）を定義したが、現状 Recolly には計測ツールが一切入っていない。
この PR で「何を計測するか」「どのツールで計測するか」を確定させる。

## 変更内容

### 新規追加
- **`docs/adr/0041-プロダクト分析ツールにposthogを採用.md`** — GA4 / Plausible / Mixpanel / 併用との比較と決定理由
- **`docs/superpowers/specs/2026-04-13-analytics-tracking-design.md`** — 実装設計（イベント定義、モジュール構成、プライバシー対応、テスト方針）

### 変更
- **`frontend/.env.example`** — `VITE_POSTHOG_KEY` / `VITE_POSTHOG_HOST` のプレースホルダーを追加

## Phase 1 イベント（4つ）

| イベント | 発火場所 | 目的 |
|---|---|---|
| \`\$pageview\` | PostHog 自動 | トラフィック分析 |
| \`\$identify\` | ログイン成功時 | 匿名→ユーザー紐付け、リテンション分析 |
| \`signup_completed\` | 新規登録成功時 | 登録 CV |
| \`record_created\` | 記録作成成功時 | アクティベーション + **ジャンル横断率** |

これだけで marketing-context で定義した全指標を計測可能。

## なぜ PostHog か

- プロダクト分析（リテンション・カスタム指標・ファネル）が本業
- 無料枠 100 万イベント/月で個人開発では事実上無制限
- identify 前は匿名・後から紐付けという方式で Cookie 同意バナー不要
- 「ジャンル横断率」のようなカスタム指標が Insight で簡単に定義できる

詳細は ADR-0041 参照。

## スコープ外（別 PR で対応）

- 実装コード（`posthog-js` の追加、イベント発火、プライバシーポリシーページ）
- writing-plans での実装プラン作成
- Phase 2 以降のイベント追加

## Test plan

- [ ] spec と ADR の内容レビュー
- [ ] イベント定義と marketing-context の指標が矛盾しないことを確認
- [ ] プライバシー方針（Cookie 同意バナーなし + privacy policy）が適切か確認
- [ ] 次のステップ（writing-plans → 実装）の見通しが立っているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)