### PR TITLE
fix(frontend): LibraryPage カードグリッドの overflow 崩れを修正

### DIFF
--- a/frontend/src/pages/LibraryPage/LibraryPage.module.css
+++ b/frontend/src/pages/LibraryPage/LibraryPage.module.css
@@ -119,6 +119,19 @@
   margin-bottom: var(--spacing-lg);
 }
 
+/*
+ * 各レコードを包む motion.div が grid/flex の直接の子になるため、
+ * min-width: 0 を強制して、子要素（カバー画像等）の intrinsic 幅で
+ * トラックが広がり、レイアウトが崩れるのを防ぐ。
+ * (RecordCardItem の .card 側にも min-width: 0 はあるが、あれは
+ *  ラッパー越しでは効かないためここで補う)
+ */
+.cardGrid > *,
+.compactList > *,
+.list > * {
+  min-width: 0;
+}
+
 /* コンパクトリスト */
 .compactList {
   margin-bottom: var(--spacing-lg);


### PR DESCRIPTION
Issue #125 の staggered fade-in アニメ追加で、記録アイテムを
motion.div でラップしたところ、grid の直接の子が motion.div に
変わり RecordCardItem 側の min-width: 0 が効かなくなり、カバー
画像の intrinsic 幅でトラックが広がってカードが画面からはみ出す
状態になっていた。

ラッパー側にも min-width: 0 を当てて修正。compact/list レイアウトの
flex コンテナでも同じ崩れが潜在的にあり得るので併せて指定する。

https://claude.ai/code/session_01Ssp3eXN9mmw6CCDqieD6Rg