### PR TITLE
feat(analytics): PostHog でプロダクト分析基盤を導入 (Phase 1)

### DIFF
--- a/docs/superpowers/plans/2026-04-13-analytics-tracking.md
+++ b/docs/superpowers/plans/2026-04-13-analytics-tracking.md
@@ -1,0 +1,2101 @@
+# Analytics Tracking (PostHog Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Recolly フロントエンドに PostHog を導入し、Phase 1 の 4 イベント（`$pageview` / `$identify` / `signup_completed` / `record_created`）を計測できる状態にする。
+
+**Architecture:** `frontend/src/lib/analytics/` に PostHog の薄いラッパーを置き、各発火ポイントからそのラッパーを呼ぶ。PageView は React Router の `useLocation()` を監視して手動発火する。identify/reset は `AuthProvider` の `user` state 変化を `useEffect` で監視する方式で統一する。プライバシーポリシーページ `/privacy` を新設し、全レイアウトの末尾に Footer を挿入して `/privacy` リンクを常に露出する。
+
+**Tech Stack:** `posthog-js` / React 19 / TypeScript / React Router 7 / Vitest + React Testing Library
+
+**Spec:** `docs/superpowers/specs/2026-04-13-analytics-tracking-design.md`
+**ADR:** `docs/adr/0041-プロダクト分析ツールにposthogを採用.md`
+**Issue:** IKcoding-jp/Recolly#143
+
+---
+
+## 設計判断サマリ
+
+| 判断事項 | 決定 | 理由 |
+|---|---|---|
+| pageview 発火方式 | SDK 初期化時に `capture_pageview: false`、全て手動発火 | SPA 初回と location 変化を一貫して扱うため。SDK の自動発火と二重送信を避ける |
+| identify/reset 発火方式 | `AuthProvider` 内 `useEffect([user])` で user state を監視 | login / signup / OAuth complete / initial session 復帰 / logout の全パスで確実に発火する |
+| record_created 呼び出し元 | 呼び出しページで明示 capture（`SearchPage`, `RecommendationsPage`） | 副作用を API ラッパーに隠さない。どの画面から発生したかが明示的になる |
+| フッター適用範囲 | 全レイアウト（認証済 / オプショナル認証 / 非認証ページ）末尾に共通 Footer | `/privacy` をどの画面からも 1 クリックで辿れるようにするため（Cookie バナー非採用の代替露出） |
+| 環境変数未設定時の挙動 | `init` 内で key/host が空なら何もしない（例外も投げない） | ローカル `.env.local` を空で起動するケースを壊さない |
+
+---
+
+## File Structure
+
+**新規作成:**
+
+- `frontend/src/lib/analytics/events.ts` — イベント名の定数定義（tagged union 型）
+- `frontend/src/lib/analytics/posthog.ts` — PostHog 初期化 + ラッパー API
+- `frontend/src/lib/analytics/posthog.test.ts` — ラッパーのユニットテスト
+- `frontend/src/components/PageviewTracker/PageviewTracker.tsx` — `useLocation` を監視して `$pageview` を発火
+- `frontend/src/components/PageviewTracker/PageviewTracker.test.tsx` — ページビュートラッカーのテスト
+- `frontend/src/components/ui/Footer/Footer.tsx` — 共通フッターコンポーネント
+- `frontend/src/components/ui/Footer/Footer.module.css` — フッターのスタイル
+- `frontend/src/components/ui/Footer/Footer.test.tsx` — フッターのテスト
+- `frontend/src/pages/PrivacyPage/PrivacyPage.tsx` — プライバシーポリシーページ
+- `frontend/src/pages/PrivacyPage/PrivacyPage.module.css` — プライバシーポリシーページ用スタイル
+- `frontend/src/pages/PrivacyPage/PrivacyPage.test.tsx` — プライバシーポリシーページのテスト
+
+**修正:**
+
+- `frontend/package.json` — `posthog-js` を dependencies に追加
+- `frontend/src/main.tsx` — PostHog 初期化呼び出し
+- `frontend/src/App.tsx` — `<PageviewTracker />` の配置 + `/privacy` ルート追加 + 各レイアウトに `<Footer />` 挿入
+- `frontend/src/App.module.css` — フッター分のスペース調整
+- `frontend/src/contexts/AuthContext.tsx` — `user` state 監視で identify/reset
+- `frontend/src/contexts/AuthContext.test.tsx` — identify/reset の発火検証を追加
+- `frontend/src/pages/SignUpPage/SignUpPage.tsx` — `signup_completed` 発火（method='email'）
+- `frontend/src/pages/SignUpPage/SignUpPage.test.tsx` — 発火検証を追加
+- `frontend/src/pages/OauthUsernamePage/OauthUsernamePage.tsx` — `signup_completed` 発火（method='google'）
+- `frontend/src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx`（存在確認して無ければ新規） — 発火検証
+- `frontend/src/pages/SearchPage/SearchPage.tsx` — `record_created` 発火
+- `frontend/src/pages/SearchPage/SearchPage.test.tsx` — 発火検証を追加
+- `frontend/src/pages/RecommendationsPage/RecommendationsPage.tsx` — `record_created` 発火
+- `frontend/src/pages/RecommendationsPage/RecommendationsPage.test.tsx`（存在確認） — 発火検証
+
+---
+
+## Task 1: `posthog-js` を依存に追加
+
+**Files:**
+- Modify: `frontend/package.json`
+- Modify: `frontend/package-lock.json`（自動更新）
+
+- [ ] **Step 1: npm でインストール**
+
+```bash
+cd frontend && npm install posthog-js
+```
+
+Expected: `posthog-js` が `dependencies` に追加され、`package-lock.json` が更新される。
+
+- [ ] **Step 2: インストール結果を確認**
+
+```bash
+cd frontend && grep -A 1 '"posthog-js"' package.json
+```
+
+Expected: `"posthog-js": "^1.x.x"` の形式で表示される。
+
+- [ ] **Step 3: ビルドと型チェックが壊れていないこと**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add frontend/package.json frontend/package-lock.json
+git commit -m "chore(frontend): posthog-js を依存に追加"
+```
+
+---
+
+## Task 2: イベント名の定数定義（`events.ts`）
+
+**Files:**
+- Create: `frontend/src/lib/analytics/events.ts`
+
+- [ ] **Step 1: 定数ファイルを作成**
+
+`frontend/src/lib/analytics/events.ts`:
+
+```ts
+/**
+ * PostHog に送信するイベント名の定数定義。
+ * 文字列リテラルの typo を防ぐため、発火側は必ずこの定数経由で指定する。
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 2.1 節
+ */
+export const ANALYTICS_EVENTS = {
+  PAGEVIEW: '$pageview',
+  SIGNUP_COMPLETED: 'signup_completed',
+  RECORD_CREATED: 'record_created',
+} as const
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS]
+
+/** signup_completed のプロパティ */
+export type SignupCompletedProps = {
+  method: 'email' | 'google'
+}
+
+/** record_created のプロパティ */
+export type RecordCreatedProps = {
+  media_type: 'anime' | 'movie' | 'drama' | 'book' | 'manga' | 'game'
+}
+```
+
+- [ ] **Step 2: 型チェックでエラーがないこと**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/lib/analytics/events.ts
+git commit -m "feat(analytics): イベント名定数と型定義を追加"
+```
+
+---
+
+## Task 3: PostHog ラッパー（`posthog.ts`）— テスト先行
+
+**Files:**
+- Create: `frontend/src/lib/analytics/posthog.test.ts`
+- Create: `frontend/src/lib/analytics/posthog.ts`
+
+- [ ] **Step 1: テストファイルを作成（failing test）**
+
+`frontend/src/lib/analytics/posthog.test.ts`:
+
+```ts
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// posthog-js をモック化。import されるより前に vi.mock を呼ぶ必要がある
+vi.mock('posthog-js', () => ({
+  default: {
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+  },
+}))
+
+import posthog from 'posthog-js'
+import {
+  initAnalytics,
+  identifyUser,
+  resetAnalytics,
+  captureEvent,
+  capturePageview,
+} from './posthog'
+
+describe('analytics/posthog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('initAnalytics', () => {
+    it('key と host が両方指定されたとき posthog.init を呼ぶ', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      expect(posthog.init).toHaveBeenCalledWith('phc_test', {
+        api_host: 'https://us.i.posthog.com',
+        capture_pageview: false,
+        persistence: 'localStorage+cookie',
+      })
+    })
+
+    it('key が未設定なら posthog.init を呼ばない', () => {
+      initAnalytics({ key: '', host: 'https://us.i.posthog.com' })
+      expect(posthog.init).not.toHaveBeenCalled()
+    })
+
+    it('host が未設定なら posthog.init を呼ばない', () => {
+      initAnalytics({ key: 'phc_test', host: '' })
+      expect(posthog.init).not.toHaveBeenCalled()
+    })
+
+    it('key と host が undefined でも例外を投げない', () => {
+      expect(() => initAnalytics({ key: undefined, host: undefined })).not.toThrow()
+      expect(posthog.init).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('identifyUser', () => {
+    it('未 init 状態でも例外を投げない', () => {
+      expect(() =>
+        identifyUser({
+          id: 1,
+          signup_method: 'email',
+          signup_date: '2026-04-13T00:00:00Z',
+        }),
+      ).not.toThrow()
+    })
+
+    it('init 済みなら posthog.identify を distinct_id と $set プロパティ付きで呼ぶ', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      identifyUser({
+        id: 42,
+        signup_method: 'google',
+        signup_date: '2026-04-13T00:00:00Z',
+      })
+      expect(posthog.identify).toHaveBeenCalledWith('42', {
+        signup_method: 'google',
+        signup_date: '2026-04-13T00:00:00Z',
+      })
+    })
+  })
+
+  describe('resetAnalytics', () => {
+    it('init 済みなら posthog.reset を呼ぶ', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      resetAnalytics()
+      expect(posthog.reset).toHaveBeenCalled()
+    })
+
+    it('未 init 状態でも例外を投げない', () => {
+      expect(() => resetAnalytics()).not.toThrow()
+    })
+  })
+
+  describe('captureEvent', () => {
+    it('init 済みなら posthog.capture にイベント名とプロパティを渡す', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      captureEvent('signup_completed', { method: 'email' })
+      expect(posthog.capture).toHaveBeenCalledWith('signup_completed', { method: 'email' })
+    })
+
+    it('未 init 状態でも例外を投げない', () => {
+      expect(() => captureEvent('signup_completed', { method: 'email' })).not.toThrow()
+    })
+  })
+
+  describe('capturePageview', () => {
+    it('init 済みなら $pageview を $current_url 付きで posthog.capture に渡す', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      capturePageview('/dashboard')
+      expect(posthog.capture).toHaveBeenCalledWith('$pageview', {
+        $current_url: '/dashboard',
+      })
+    })
+
+    it('未 init 状態でも例外を投げない', () => {
+      expect(() => capturePageview('/dashboard')).not.toThrow()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: テストを走らせて fail することを確認**
+
+```bash
+cd frontend && npm run test -- src/lib/analytics/posthog.test.ts
+```
+
+Expected: `Cannot find module './posthog'` または類似のエラー。
+
+- [ ] **Step 3: ラッパー本体を実装**
+
+`frontend/src/lib/analytics/posthog.ts`:
+
+```ts
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, type AnalyticsEventName } from './events'
+
+/**
+ * PostHog のラッパー。
+ * - 環境変数が未設定ならサイレントに何もしない（ローカル開発で .env.local が空でも壊さない）
+ * - PostHog の init / capture が失敗しても Recolly 本体は継続動作する（例外は握りつぶして console.warn）
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 3.4 節
+ */
+
+let initialized = false
+
+type InitOptions = {
+  key: string | undefined
+  host: string | undefined
+}
+
+export function initAnalytics({ key, host }: InitOptions): void {
+  if (!key || !host) {
+    // 環境変数未設定時は何もしない（開発環境で .env.local が無いケースを想定）
+    return
+  }
+  try {
+    posthog.init(key, {
+      api_host: host,
+      // SDK の自動 pageview は無効化し、React Router の location 変化時に手動発火する
+      capture_pageview: false,
+      persistence: 'localStorage+cookie',
+    })
+    initialized = true
+  } catch (error) {
+    console.warn('[analytics] PostHog init failed:', error)
+  }
+}
+
+export type IdentifyPayload = {
+  id: number
+  signup_method: 'email' | 'google'
+  signup_date: string
+}
+
+export function identifyUser(payload: IdentifyPayload): void {
+  if (!initialized) return
+  try {
+    posthog.identify(String(payload.id), {
+      signup_method: payload.signup_method,
+      signup_date: payload.signup_date,
+    })
+  } catch (error) {
+    console.warn('[analytics] identify failed:', error)
+  }
+}
+
+export function resetAnalytics(): void {
+  if (!initialized) return
+  try {
+    posthog.reset()
+  } catch (error) {
+    console.warn('[analytics] reset failed:', error)
+  }
+}
+
+export function captureEvent<P extends Record<string, unknown>>(
+  eventName: AnalyticsEventName,
+  properties: P,
+): void {
+  if (!initialized) return
+  try {
+    posthog.capture(eventName, properties)
+  } catch (error) {
+    console.warn('[analytics] capture failed:', error)
+  }
+}
+
+export function capturePageview(currentUrl: string): void {
+  if (!initialized) return
+  try {
+    posthog.capture(ANALYTICS_EVENTS.PAGEVIEW, { $current_url: currentUrl })
+  } catch (error) {
+    console.warn('[analytics] pageview capture failed:', error)
+  }
+}
+
+/** テスト用: 内部状態をリセットする（プロダクションコードからは呼ばない） */
+export function __resetForTest(): void {
+  initialized = false
+}
+```
+
+- [ ] **Step 4: posthog.test.ts の beforeEach で `__resetForTest` を呼ぶよう更新**
+
+`frontend/src/lib/analytics/posthog.test.ts` の import 行に `__resetForTest` を追加し、beforeEach を修正:
+
+```ts
+import {
+  initAnalytics,
+  identifyUser,
+  resetAnalytics,
+  captureEvent,
+  capturePageview,
+  __resetForTest,
+} from './posthog'
+
+// ...既存の describe 内
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetForTest()
+  })
+```
+
+- [ ] **Step 5: テストが全部パスすることを確認**
+
+```bash
+cd frontend && npm run test -- src/lib/analytics/posthog.test.ts
+```
+
+Expected: 全テストが PASS。
+
+- [ ] **Step 6: lint をかけてエラー無しを確認**
+
+```bash
+cd frontend && npm run lint -- src/lib/analytics/
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add frontend/src/lib/analytics/posthog.ts frontend/src/lib/analytics/posthog.test.ts
+git commit -m "feat(analytics): PostHog ラッパーとユニットテストを追加"
+```
+
+---
+
+## Task 4: `main.tsx` で PostHog 初期化
+
+**Files:**
+- Modify: `frontend/src/main.tsx`
+
+- [ ] **Step 1: `main.tsx` を修正**
+
+`frontend/src/main.tsx`:
+
+```tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import App from './App.tsx'
+import { initAnalytics } from './lib/analytics/posthog'
+
+// PostHog 初期化。環境変数が未設定ならサイレントに no-op（開発環境で .env.local が空でも壊さない）
+initAnalytics({
+  key: import.meta.env.VITE_POSTHOG_KEY as string | undefined,
+  host: import.meta.env.VITE_POSTHOG_HOST as string | undefined,
+})
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+)
+```
+
+- [ ] **Step 2: 型チェックが通ることを確認**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: 既存テスト全体がこけていないことを確認**
+
+```bash
+cd frontend && npm run test
+```
+
+Expected: 既存の全テストが PASS（この段階で新規追加したテストも含めて）。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add frontend/src/main.tsx
+git commit -m "feat(analytics): main.tsx で PostHog を初期化"
+```
+
+---
+
+## Task 5: `PageviewTracker` コンポーネント — テスト先行
+
+**Files:**
+- Create: `frontend/src/components/PageviewTracker/PageviewTracker.test.tsx`
+- Create: `frontend/src/components/PageviewTracker/PageviewTracker.tsx`
+
+- [ ] **Step 1: テストファイルを作成（failing test）**
+
+`frontend/src/components/PageviewTracker/PageviewTracker.test.tsx`:
+
+```tsx
+import { render } from '@testing-library/react'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/analytics/posthog', () => ({
+  capturePageview: vi.fn(),
+}))
+
+import { capturePageview } from '../../lib/analytics/posthog'
+import { PageviewTracker } from './PageviewTracker'
+
+function TestNavigator({ to }: { to: string }) {
+  const navigate = useNavigate()
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      go
+    </button>
+  )
+}
+
+describe('PageviewTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('初回マウント時に現在のパスで capturePageview を呼ぶ', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <PageviewTracker />
+      </MemoryRouter>,
+    )
+    expect(capturePageview).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('location 変化で新しいパスを渡して capturePageview を再度呼ぶ', async () => {
+    const { getByText } = render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <PageviewTracker />
+        <Routes>
+          <Route path="/dashboard" element={<TestNavigator to="/library" />} />
+          <Route path="/library" element={<div>library</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    vi.mocked(capturePageview).mockClear()
+    getByText('go').click()
+
+    expect(capturePageview).toHaveBeenCalledWith('/library')
+  })
+})
+```
+
+- [ ] **Step 2: テストを走らせて fail することを確認**
+
+```bash
+cd frontend && npm run test -- src/components/PageviewTracker/PageviewTracker.test.tsx
+```
+
+Expected: `Cannot find module './PageviewTracker'` または類似のエラー。
+
+- [ ] **Step 3: コンポーネント本体を実装**
+
+`frontend/src/components/PageviewTracker/PageviewTracker.tsx`:
+
+```tsx
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { capturePageview } from '../../lib/analytics/posthog'
+
+/**
+ * React Router の location 変化を監視して PostHog に $pageview を送る。
+ * SDK の自動 pageview は無効化しているため、初回マウント時もここで手動発火する。
+ * BrowserRouter の子孫として配置する必要がある（useLocation を使うため）。
+ */
+export function PageviewTracker(): null {
+  const location = useLocation()
+
+  useEffect(() => {
+    capturePageview(location.pathname + location.search)
+  }, [location.pathname, location.search])
+
+  return null
+}
+```
+
+- [ ] **Step 4: テストが全部パスすることを確認**
+
+```bash
+cd frontend && npm run test -- src/components/PageviewTracker/PageviewTracker.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 5: テストのアサーションを pathname + search に合わせる**
+
+`PageviewTracker.test.tsx` の `expect(capturePageview).toHaveBeenCalledWith('/dashboard')` が `'/dashboard'`（search 無し）で呼ばれる。search が無い場合は空文字連結なのでそのまま通る。念のため実行結果を確認する。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/components/PageviewTracker/
+git commit -m "feat(analytics): PageviewTracker コンポーネントを追加（SPA 遷移で \$pageview 発火）"
+```
+
+---
+
+## Task 6: `App.tsx` に `PageviewTracker` を組み込む
+
+**Files:**
+- Modify: `frontend/src/App.tsx:143-258`（BrowserRouter の内側、AuthProvider の内側、Suspense の前に配置）
+
+- [ ] **Step 1: `App.tsx` に import を追加**
+
+`frontend/src/App.tsx` 上部に追加:
+
+```tsx
+import { PageviewTracker } from './components/PageviewTracker/PageviewTracker'
+```
+
+- [ ] **Step 2: `BrowserRouter` 内に `<PageviewTracker />` を配置**
+
+`App()` 関数の `return` を以下に差し替え：
+
+```tsx
+  return (
+    <BrowserRouter>
+      <AuthProvider>
+        <PageviewTracker />
+        <AnimatePresence>
+          {needRefresh && (
+            <UpdatePrompt
+              onRefresh={() => void updateServiceWorker(true)}
+              onClose={() => setNeedRefresh(false)}
+            />
+          )}
+        </AnimatePresence>
+        <Suspense fallback={<div className={appStyles.loading}>読み込み中...</div>}>
+          <Routes>
+            {/* 既存のルート定義はそのまま */}
+          </Routes>
+        </Suspense>
+      </AuthProvider>
+    </BrowserRouter>
+  )
+```
+
+- [ ] **Step 3: 型チェック・既存テスト・lint を全て実行**
+
+```bash
+cd frontend && npm run typecheck && npm run lint && npm run test
+```
+
+Expected: 全て PASS。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat(analytics): App.tsx に PageviewTracker を組み込む"
+```
+
+---
+
+## Task 7: `AuthContext` で identify/reset — テスト先行
+
+**Files:**
+- Modify: `frontend/src/contexts/AuthContext.test.tsx`
+- Modify: `frontend/src/contexts/AuthContext.tsx`
+
+- [ ] **Step 1: 既存テストを確認し、mock 設定を調べる**
+
+```bash
+cd frontend && cat src/contexts/AuthContext.test.tsx | head -40
+```
+
+既存 mock パターンを把握する。
+
+- [ ] **Step 2: テストに mock を追加して失敗テストを書く**
+
+`frontend/src/contexts/AuthContext.test.tsx` の既存 `vi.mock` の近くに追加:
+
+```ts
+vi.mock('../lib/analytics/posthog', () => ({
+  identifyUser: vi.fn(),
+  resetAnalytics: vi.fn(),
+}))
+```
+
+import 行に追加:
+
+```ts
+import { identifyUser, resetAnalytics } from '../lib/analytics/posthog'
+```
+
+describe 内に以下のテストを追加（既存 describe の末尾でよい）:
+
+```tsx
+describe('analytics integration', () => {
+  it('ログイン成功時に identifyUser が呼ばれる', async () => {
+    // 既存の login mock セットアップ（authApi.login が {user} を返すよう設定）を踏襲
+    vi.mocked(authApi.login).mockResolvedValue({
+      user: {
+        id: 7,
+        username: 'alice',
+        email: 'alice@example.com',
+        provider: 'email',
+        created_at: '2026-04-01T00:00:00Z',
+      } as User,
+    })
+    vi.mocked(authApi.getCurrentUser).mockRejectedValue(new Error('not logged in'))
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    })
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await result.current.login('alice@example.com', 'secret')
+    })
+
+    await waitFor(() => {
+      expect(identifyUser).toHaveBeenCalledWith({
+        id: 7,
+        signup_method: 'email',
+        signup_date: '2026-04-01T00:00:00Z',
+      })
+    })
+  })
+
+  it('ログアウト時に resetAnalytics が呼ばれる', async () => {
+    vi.mocked(authApi.getCurrentUser).mockResolvedValue({
+      user: {
+        id: 7,
+        username: 'alice',
+        email: 'alice@example.com',
+        provider: 'google_oauth2',
+        created_at: '2026-04-01T00:00:00Z',
+      } as User,
+    })
+    vi.mocked(authApi.logout).mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    })
+
+    await waitFor(() => expect(result.current.user).not.toBeNull())
+
+    await act(async () => {
+      await result.current.logout()
+    })
+
+    await waitFor(() => {
+      expect(resetAnalytics).toHaveBeenCalled()
+    })
+  })
+
+  it('初回セッション復帰時に identifyUser が呼ばれる', async () => {
+    vi.mocked(authApi.getCurrentUser).mockResolvedValue({
+      user: {
+        id: 99,
+        username: 'bob',
+        email: 'bob@example.com',
+        provider: 'google_oauth2',
+        created_at: '2026-03-15T00:00:00Z',
+      } as User,
+    })
+
+    renderHook(() => useAuth(), {
+      wrapper: ({ children }) => <AuthProvider>{children}</AuthProvider>,
+    })
+
+    await waitFor(() => {
+      expect(identifyUser).toHaveBeenCalledWith({
+        id: 99,
+        signup_method: 'google',
+        signup_date: '2026-03-15T00:00:00Z',
+      })
+    })
+  })
+})
+```
+
+> **注意:** `User` 型は `frontend/src/lib/types.ts` で定義されている。既存 AuthContext.test.tsx の import 行を確認し、`provider`, `created_at` の型が合うか調整すること。合わない場合は必要なフィールドだけ含めて `as unknown as User` でキャストして良い。
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+```bash
+cd frontend && npm run test -- src/contexts/AuthContext.test.tsx
+```
+
+Expected: 新規 3 テストが fail（`identifyUser` / `resetAnalytics` が呼ばれない）。
+
+- [ ] **Step 4: `AuthContext.tsx` を修正**
+
+`frontend/src/contexts/AuthContext.tsx` の `useEffect` と `logout` の近辺を以下のように変更：
+
+- 既存 `useEffect(() => { authApi.getCurrentUser()... }, [])` はそのまま残す。
+- 新規 `useEffect` を追加して `user` 変化を監視し、`identifyUser` / `resetAnalytics` を呼ぶ。
+- ただし初期ロード中（`isLoading === true` かつ `user === null`）の reset は無駄なので、`isLoading` が false のタイミングで判定する。
+
+差分:
+
+```tsx
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { authApi, ApiError } from '../lib/api'
+import type { User } from '../lib/types'
+import { AuthContext } from './authContextValue'
+import { identifyUser, resetAnalytics } from '../lib/analytics/posthog'
+
+// 省略...
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  // identify が1度発火したかを記録する（同じユーザーで何度も identify しないように）
+  const lastIdentifiedIdRef = useRef<number | null>(null)
+
+  // 初回ロード時にセッション確認
+  useEffect(() => {
+    authApi
+      .getCurrentUser()
+      .then((data) => setUser(data.user))
+      .catch(() => setUser(null))
+      .finally(() => setIsLoading(false))
+  }, [])
+
+  // user state の変化に応じて PostHog の identify / reset を発火
+  useEffect(() => {
+    if (isLoading) return
+    if (user) {
+      if (lastIdentifiedIdRef.current === user.id) return
+      lastIdentifiedIdRef.current = user.id
+      identifyUser({
+        id: user.id,
+        // provider が 'google_oauth2' ならば 'google'、それ以外は 'email' に寄せる
+        signup_method: user.provider === 'google_oauth2' ? 'google' : 'email',
+        signup_date: user.created_at,
+      })
+    } else if (lastIdentifiedIdRef.current !== null) {
+      // 直前に identify していたユーザーがログアウトした場合のみ reset する
+      lastIdentifiedIdRef.current = null
+      resetAnalytics()
+    }
+  }, [user, isLoading])
+
+  // 以降は既存コードのまま
+```
+
+> **注意:** `User` 型の `provider` 値が 'google_oauth2' で来るか 'google' で来るかは `lib/types.ts` 実装依存。実装時に確認し、テストの `provider` 値と一致させること。
+
+- [ ] **Step 5: テストを実行して PASS を確認**
+
+```bash
+cd frontend && npm run test -- src/contexts/AuthContext.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 6: 型チェック + lint**
+
+```bash
+cd frontend && npm run typecheck && npm run lint -- src/contexts/
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add frontend/src/contexts/AuthContext.tsx frontend/src/contexts/AuthContext.test.tsx
+git commit -m "feat(analytics): AuthContext で identify/reset を自動発火"
+```
+
+---
+
+## Task 8: `SignUpPage` で `signup_completed` 発火 — テスト先行
+
+**Files:**
+- Modify: `frontend/src/pages/SignUpPage/SignUpPage.test.tsx`
+- Modify: `frontend/src/pages/SignUpPage/SignUpPage.tsx`
+
+- [ ] **Step 1: 既存の SignUpPage.test.tsx を確認**
+
+```bash
+cd frontend && head -60 src/pages/SignUpPage/SignUpPage.test.tsx
+```
+
+既存テストパターンを踏襲する。
+
+- [ ] **Step 2: mock と失敗テストを追加**
+
+`SignUpPage.test.tsx` に以下を追加:
+
+```ts
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+  identifyUser: vi.fn(),
+  resetAnalytics: vi.fn(),
+}))
+
+import { captureEvent } from '../../lib/analytics/posthog'
+```
+
+新しい it ケースを追加:
+
+```tsx
+it('登録成功時に signup_completed イベントを method=email で発火する', async () => {
+  // 既存の signup 成功パターンのテストと同じセットアップを行う
+  // （authApi.signup のモック、navigate モック等）
+  const user = userEvent.setup()
+  // ... 既存の描画 + 入力ロジックと同じ
+  // 例: フォームに値を入力して submit
+  await user.click(screen.getByRole('button', { name: /アカウントを作成/ }))
+
+  await waitFor(() => {
+    expect(captureEvent).toHaveBeenCalledWith('signup_completed', { method: 'email' })
+  })
+})
+```
+
+> **注意:** 既存の成功パターンのテストをコピー&調整してよい。セットアップの詳細は既存テストを参考にする。
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/SignUpPage/SignUpPage.test.tsx
+```
+
+Expected: 新規テストが fail。
+
+- [ ] **Step 4: `SignUpPage.tsx` を修正**
+
+`SignUpPage.tsx` の `handleSubmit` 内を変更:
+
+```tsx
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
+
+// ...
+
+const handleSubmit = async (e: FormEvent) => {
+  e.preventDefault()
+  setError('')
+
+  if (password !== passwordConfirmation) {
+    setError('パスワードが一致しません')
+    return
+  }
+
+  setIsSubmitting(true)
+
+  try {
+    await signup(username, email, password, passwordConfirmation)
+    // 登録完了イベント発火（method: email）
+    captureEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method: 'email' })
+    navigate('/dashboard')
+  } catch (err) {
+    if (err instanceof ApiError) {
+      setError(err.message)
+    } else {
+      setError('登録に失敗しました')
+    }
+  } finally {
+    setIsSubmitting(false)
+  }
+}
+```
+
+- [ ] **Step 5: テストを実行して PASS を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/SignUpPage/SignUpPage.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/pages/SignUpPage/
+git commit -m "feat(analytics): SignUpPage で signup_completed を発火（method=email）"
+```
+
+---
+
+## Task 9: `OauthUsernamePage` で `signup_completed` 発火 — テスト先行
+
+**Files:**
+- Modify or Create: `frontend/src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx`
+- Modify: `frontend/src/pages/OauthUsernamePage/OauthUsernamePage.tsx`
+
+- [ ] **Step 1: 既存テストの有無を確認**
+
+```bash
+cd frontend && ls src/pages/OauthUsernamePage/
+```
+
+`OauthUsernamePage.test.tsx` が存在するか確認する。無ければ新規作成。
+
+- [ ] **Step 2a: 既存テストがあればそこに mock とケースを追加**
+
+既存ファイルに mock 追加:
+
+```ts
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+}))
+import { captureEvent } from '../../lib/analytics/posthog'
+```
+
+新規 it ケースを追加:
+
+```tsx
+it('登録完了時に signup_completed イベントを method=google で発火する', async () => {
+  // 既存の成功ケースと同じセットアップ（oauthApi.completeRegistration を成功レスポンスでモック）
+  const user = userEvent.setup()
+  // ... フォーム入力して submit
+  await user.click(screen.getByRole('button', { name: /登録する/ }))
+
+  await waitFor(() => {
+    expect(captureEvent).toHaveBeenCalledWith('signup_completed', { method: 'google' })
+  })
+})
+```
+
+- [ ] **Step 2b: 既存テストが無い場合は最小限のテストファイルを新規作成**
+
+`frontend/src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx`:
+
+```tsx
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/api', () => ({
+  oauthApi: {
+    completeRegistration: vi.fn(),
+  },
+  ApiError: class extends Error {
+    constructor(
+      message: string,
+      public status: number,
+    ) {
+      super(message)
+    }
+  },
+}))
+
+vi.mock('../../contexts/useAuth', () => ({
+  useAuth: () => ({
+    setUser: vi.fn(),
+  }),
+}))
+
+const navigateMock = vi.fn()
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom')
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  }
+})
+
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+}))
+
+import { oauthApi } from '../../lib/api'
+import { captureEvent } from '../../lib/analytics/posthog'
+import { OauthUsernamePage } from './OauthUsernamePage'
+
+describe('OauthUsernamePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('登録完了時に signup_completed イベントを method=google で発火する', async () => {
+    vi.mocked(oauthApi.completeRegistration).mockResolvedValue({
+      user: {
+        id: 1,
+        username: 'alice',
+        email: 'alice@example.com',
+        email_missing: false,
+        provider: 'google_oauth2',
+        created_at: '2026-04-13T00:00:00Z',
+      },
+    } as Awaited<ReturnType<typeof oauthApi.completeRegistration>>)
+
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <OauthUsernamePage />
+      </MemoryRouter>,
+    )
+
+    await user.type(screen.getByLabelText(/ユーザー名/), 'alice')
+    await user.click(screen.getByRole('button', { name: /登録する/ }))
+
+    await waitFor(() => {
+      expect(captureEvent).toHaveBeenCalledWith('signup_completed', { method: 'google' })
+    })
+  })
+})
+```
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx
+```
+
+Expected: 新規テストが fail。
+
+- [ ] **Step 4: `OauthUsernamePage.tsx` を修正**
+
+`handleSubmit` を以下のように変更:
+
+```tsx
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
+
+// ...
+
+const handleSubmit = async (e: FormEvent) => {
+  e.preventDefault()
+  setError('')
+  setIsSubmitting(true)
+
+  try {
+    const response = await oauthApi.completeRegistration(username)
+    setUser(response.user)
+    // OAuth 新規登録完了イベント発火
+    captureEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method: 'google' })
+
+    if (response.user.email_missing) {
+      navigate('/auth/email-setup', { replace: true })
+    } else {
+      navigate('/dashboard', { replace: true })
+    }
+  } catch (err) {
+    if (err instanceof ApiError) {
+      setError(err.message)
+    } else {
+      setError('登録に失敗しました')
+    }
+  } finally {
+    setIsSubmitting(false)
+  }
+}
+```
+
+- [ ] **Step 5: テストを実行して PASS を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/pages/OauthUsernamePage/
+git commit -m "feat(analytics): OauthUsernamePage で signup_completed を発火（method=google）"
+```
+
+---
+
+## Task 10: `SearchPage` で `record_created` 発火 — テスト先行
+
+**Files:**
+- Modify: `frontend/src/pages/SearchPage/SearchPage.test.tsx`
+- Modify: `frontend/src/pages/SearchPage/SearchPage.tsx`
+
+- [ ] **Step 1: 既存の SearchPage.test.tsx を確認**
+
+```bash
+cd frontend && grep -n "recordsApi.create\|handleConfirmRecord\|describe\|it(" src/pages/SearchPage/SearchPage.test.tsx | head -40
+```
+
+既存の記録作成成功ケースのセットアップを把握する。
+
+- [ ] **Step 2: mock とテストケース追加**
+
+`SearchPage.test.tsx`:
+
+```ts
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+}))
+import { captureEvent } from '../../lib/analytics/posthog'
+```
+
+新規 it ケース追加（既存の「検索結果から記録を作成する」テストのすぐ近く）:
+
+```tsx
+it('検索結果から記録を作成したら record_created を media_type 付きで発火する', async () => {
+  // 既存の成功ケースのセットアップを流用（recordsApi.createFromSearchResult のモック等）
+  // 検索 → モーダル → 記録確定 まで実行
+  await waitFor(() => {
+    expect(captureEvent).toHaveBeenCalledWith('record_created', { media_type: 'anime' })
+  })
+})
+```
+
+> **注意:** 既存テストが media_type='anime' の作品を使っているかを確認し、値を合わせる。
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/SearchPage/SearchPage.test.tsx
+```
+
+Expected: 新規テストが fail。
+
+- [ ] **Step 4: `SearchPage.tsx` の `handleConfirmRecord` を修正**
+
+```tsx
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
+
+// ...
+
+const handleConfirmRecord = async (data: { status: RecordStatus; rating: number | null }) => {
+  if (!modalWork) return
+
+  try {
+    if (manualWorkId) {
+      // 手動登録作品: work_idで直接Record作成
+      setLoadingId('manual')
+      await recordsApi.createFromWorkId(manualWorkId, data)
+      captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
+        media_type: modalWork.media_type,
+      })
+      setManualWorkId(null)
+    } else {
+      // 検索結果作品: 既存のフロー
+      const workKey = `${modalWork.external_api_source}:${modalWork.external_api_id}`
+      setLoadingId(workKey)
+      await recordsApi.createFromSearchResult(modalWork, data)
+      captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
+        media_type: modalWork.media_type,
+      })
+      setRecordedIds((prev) => new Set(prev).add(workKey))
+    }
+    setModalWork(null)
+  } catch (err) {
+    // エラー時は capture しない（成功時のみ計測）
+    if (err instanceof ApiError) {
+      setError(err.message)
+      if (err.status === 409 && modalWork) {
+        const workKey = `${modalWork.external_api_source}:${modalWork.external_api_id}`
+        setRecordedIds((prev) => new Set(prev).add(workKey))
+        setModalWork(null)
+      }
+    }
+  } finally {
+    setLoadingId(null)
+  }
+}
+```
+
+> **型の注意:** `modalWork.media_type` が spec の union 型 (`'anime' | 'movie' | ...`) と一致することを確認する。`SearchResult.media_type` が同じ union なら型エラーは出ない。異なる場合は `as` で明示キャストする。
+
+- [ ] **Step 5: テストを実行して PASS を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/SearchPage/SearchPage.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 6: 型チェック**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add frontend/src/pages/SearchPage/
+git commit -m "feat(analytics): SearchPage で record_created を発火"
+```
+
+---
+
+## Task 11: `RecommendationsPage` で `record_created` 発火 — テスト先行
+
+**Files:**
+- Modify or Create: `frontend/src/pages/RecommendationsPage/RecommendationsPage.test.tsx`
+- Modify: `frontend/src/pages/RecommendationsPage/RecommendationsPage.tsx`
+
+- [ ] **Step 1: 既存テストを確認**
+
+```bash
+cd frontend && ls src/pages/RecommendationsPage/
+```
+
+- [ ] **Step 2: mock とテストを追加（既存ファイルがあれば追記、無ければ新規作成）**
+
+既存ファイルがあれば以下 mock を追加:
+
+```ts
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+}))
+import { captureEvent } from '../../lib/analytics/posthog'
+```
+
+新規 it ケース:
+
+```tsx
+it('レコメンドから記録を作成したら record_created を media_type 付きで発火する', async () => {
+  // recommend された作品の media_type を含んだ mock を用意
+  // 記録確定フローを実行
+  await waitFor(() => {
+    expect(captureEvent).toHaveBeenCalledWith('record_created', { media_type: 'anime' })
+  })
+})
+```
+
+既存テストが無ければ、SearchPage のテスト構造を参考に最小限のテストファイルを作成する。
+
+- [ ] **Step 3: テストを実行して失敗を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/RecommendationsPage/RecommendationsPage.test.tsx
+```
+
+Expected: 新規テストが fail。
+
+- [ ] **Step 4: `RecommendationsPage.tsx` の `handleConfirmRecord` を修正**
+
+```tsx
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
+
+// ...
+
+const handleConfirmRecord = async (recordData: {
+  status: RecordStatus
+  rating: number | null
+}) => {
+  if (!modalWork) return
+
+  const workKey = `${modalWork.external_api_source}:${modalWork.external_api_id}`
+  setRecordingId(workKey)
+
+  try {
+    await recordsApi.createFromSearchResult(
+      {
+        title: modalWork.title,
+        media_type: modalWork.media_type as MediaType,
+        description: modalWork.description,
+        cover_image_url: modalWork.cover_url,
+        total_episodes: null,
+        external_api_id: modalWork.external_api_id,
+        external_api_source: modalWork.external_api_source,
+        metadata: modalWork.metadata,
+      },
+      recordData,
+    )
+    captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
+      media_type: modalWork.media_type as MediaType,
+    })
+    setRecordedIds((prev) => new Set(prev).add(workKey))
+    setModalWork(null)
+  } catch {
+    // エラーハンドリングはRecordModal側で表示
+  } finally {
+    setRecordingId(null)
+  }
+}
+```
+
+- [ ] **Step 5: テストを実行して PASS を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/RecommendationsPage/RecommendationsPage.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/pages/RecommendationsPage/
+git commit -m "feat(analytics): RecommendationsPage で record_created を発火"
+```
+
+---
+
+## Task 12: プライバシーポリシーページ — テスト先行
+
+**Files:**
+- Create: `frontend/src/pages/PrivacyPage/PrivacyPage.test.tsx`
+- Create: `frontend/src/pages/PrivacyPage/PrivacyPage.tsx`
+- Create: `frontend/src/pages/PrivacyPage/PrivacyPage.module.css`
+
+- [ ] **Step 1: テストを作成**
+
+`frontend/src/pages/PrivacyPage/PrivacyPage.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { PrivacyPage } from './PrivacyPage'
+
+describe('PrivacyPage', () => {
+  it('タイトルが表示される', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('heading', { name: /プライバシーポリシー/ })).toBeInTheDocument()
+  })
+
+  it('PostHog を使用していることを明記している', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/PostHog/)).toBeInTheDocument()
+  })
+
+  it('PII を送信しない方針を明記している', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/感想本文|パスワード|メールアドレス/)).toBeInTheDocument()
+  })
+
+  it('opt-out の方法について言及している', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/計測を拒否|opt-out|オプトアウト/i)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: テストを実行して失敗を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/PrivacyPage/PrivacyPage.test.tsx
+```
+
+Expected: `Cannot find module './PrivacyPage'`。
+
+- [ ] **Step 3: ページ本体を実装**
+
+`frontend/src/pages/PrivacyPage/PrivacyPage.tsx`:
+
+```tsx
+import { Typography } from '../../components/ui/Typography/Typography'
+import { Divider } from '../../components/ui/Divider/Divider'
+import styles from './PrivacyPage.module.css'
+
+/**
+ * プライバシーポリシーページ (/privacy)
+ * Cookie 同意バナーは実装しない方針のため、計測内容をこのページで明示する。
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 4 節
+ */
+export function PrivacyPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.content}>
+        <Typography variant="h1">プライバシーポリシー</Typography>
+        <Divider />
+
+        <section className={styles.section}>
+          <Typography variant="h2">1. 取得する情報</Typography>
+          <p>
+            Recolly（以下「本サービス」）では、サービスの改善と利用状況の把握のため、
+            以下の情報を自動的に取得します。
+          </p>
+          <ul>
+            <li>ページの閲覧履歴（どの画面を開いたか）</li>
+            <li>操作イベント（新規登録、記録作成など）</li>
+            <li>ログイン状態（ログイン中のユーザー内部 ID）</li>
+            <li>アクセスしたブラウザ・デバイス情報</li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">2. 利用する解析ツール</Typography>
+          <p>
+            本サービスは解析ツールとして <strong>PostHog</strong> を利用しています。
+            PostHog は世界中で利用されているプロダクト分析ツールで、
+            本サービスの改善のためにイベントデータを収集します。
+          </p>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">3. 送信しない情報（匿名性の担保）</Typography>
+          <p>以下の情報は PostHog に送信しません:</p>
+          <ul>
+            <li>メールアドレス</li>
+            <li>パスワード</li>
+            <li>作品の感想本文</li>
+            <li>掲示板のコメント本文</li>
+            <li>プロフィールの自己紹介文</li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">4. 計測を拒否する方法（オプトアウト）</Typography>
+          <p>
+            計測を拒否したい場合は、ブラウザのプライバシー設定で Cookie / localStorage を
+            拒否することで PostHog のトラッキングを無効化できます。
+            本サービスは計測を無効化していても基本機能をご利用いただけます。
+          </p>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">5. 利用目的</Typography>
+          <ul>
+            <li>サービスの利用状況を把握し、機能改善に活用するため</li>
+            <li>ユーザーの継続率・離脱ポイントを分析し、体験を改善するため</li>
+            <li>不具合の発見と修正のため</li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">6. お問い合わせ</Typography>
+          <p>
+            本ポリシーに関するお問い合わせは、本サービスの GitHub リポジトリ経由で受け付けています。
+          </p>
+        </section>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: CSS を作成**
+
+`frontend/src/pages/PrivacyPage/PrivacyPage.module.css`:
+
+```css
+.page {
+  min-height: 100%;
+  padding: var(--spacing-xl) var(--spacing-md);
+}
+
+.content {
+  max-width: 720px;
+  margin: 0 auto;
+  color: var(--color-text);
+}
+
+.section {
+  margin-top: var(--spacing-xl);
+}
+
+.section p {
+  margin: var(--spacing-md) 0;
+  line-height: 1.8;
+}
+
+.section ul {
+  margin: var(--spacing-md) 0;
+  padding-left: var(--spacing-lg);
+  line-height: 1.8;
+}
+```
+
+- [ ] **Step 5: テスト実行して PASS を確認**
+
+```bash
+cd frontend && npm run test -- src/pages/PrivacyPage/PrivacyPage.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/pages/PrivacyPage/
+git commit -m "feat(analytics): プライバシーポリシーページ /privacy を追加"
+```
+
+---
+
+## Task 13: `App.tsx` に `/privacy` ルートを追加
+
+**Files:**
+- Modify: `frontend/src/App.tsx`
+
+- [ ] **Step 1: lazy import と Route を追加**
+
+`frontend/src/App.tsx` の lazy import 一覧に追加:
+
+```tsx
+const PrivacyPage = lazy(() =>
+  import('./pages/PrivacyPage/PrivacyPage').then((m) => ({ default: m.PrivacyPage })),
+)
+```
+
+`<Routes>` 内の適切な位置（非認証でアクセス可能な `/login` の近く）に追加:
+
+```tsx
+<Route
+  path="/privacy"
+  element={
+    <OptionalAuthLayout>
+      <PrivacyPage />
+    </OptionalAuthLayout>
+  }
+/>
+```
+
+- [ ] **Step 2: 型チェック + lint**
+
+```bash
+cd frontend && npm run typecheck && npm run lint
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: 全テスト実行**
+
+```bash
+cd frontend && npm run test
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add frontend/src/App.tsx
+git commit -m "feat(analytics): /privacy ルートを App.tsx に追加"
+```
+
+---
+
+## Task 14: `Footer` コンポーネント — テスト先行
+
+**Files:**
+- Create: `frontend/src/components/ui/Footer/Footer.test.tsx`
+- Create: `frontend/src/components/ui/Footer/Footer.tsx`
+- Create: `frontend/src/components/ui/Footer/Footer.module.css`
+
+- [ ] **Step 1: テスト作成**
+
+`frontend/src/components/ui/Footer/Footer.test.tsx`:
+
+```tsx
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { Footer } from './Footer'
+
+describe('Footer', () => {
+  it('プライバシーポリシーへのリンクを含む', () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    )
+    const link = screen.getByRole('link', { name: /プライバシーポリシー/ })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/privacy')
+  })
+
+  it('Recolly のブランド表記を含む', () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/Recolly/)).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: テストが fail することを確認**
+
+```bash
+cd frontend && npm run test -- src/components/ui/Footer/Footer.test.tsx
+```
+
+Expected: `Cannot find module './Footer'`。
+
+- [ ] **Step 3: コンポーネント本体を実装**
+
+`frontend/src/components/ui/Footer/Footer.tsx`:
+
+```tsx
+import { Link } from 'react-router-dom'
+import styles from './Footer.module.css'
+
+/**
+ * 全ページ共通のフッター。
+ * プライバシーポリシーへの導線を常に露出するために配置する。
+ */
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.inner}>
+        <span className={styles.brand}>© Recolly</span>
+        <nav className={styles.nav}>
+          <Link to="/privacy" className={styles.link}>
+            プライバシーポリシー
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  )
+}
+```
+
+- [ ] **Step 4: CSS を作成**
+
+`frontend/src/components/ui/Footer/Footer.module.css`:
+
+```css
+.footer {
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-white);
+  padding: var(--spacing-md) var(--spacing-lg);
+  margin-top: auto;
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  font-size: var(--font-size-label);
+  color: var(--color-text-muted);
+}
+
+.brand {
+  font-weight: var(--font-weight-medium);
+}
+
+.nav {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: var(--transition-base);
+}
+
+.link:hover {
+  color: var(--color-text);
+  text-decoration: underline;
+}
+```
+
+> **注意:** 使用している CSS 変数（`--color-border`, `--color-bg-white`, `--color-text-muted`, `--font-size-label`, `--font-weight-medium`, `--transition-base` 等）は `frontend/src/styles/tokens.css` で定義済みのものだけ使う。無い場合は tokens.css に追加する。
+
+- [ ] **Step 5: 使用しているトークンが tokens.css に存在するか確認**
+
+```bash
+cd frontend && grep -E "color-border|color-bg-white|color-text-muted|font-size-label|font-weight-medium|transition-base" src/styles/tokens.css
+```
+
+Expected: 全て定義済み。無いものがあれば tokens.css に追加する。
+
+- [ ] **Step 6: テストが PASS することを確認**
+
+```bash
+cd frontend && npm run test -- src/components/ui/Footer/Footer.test.tsx
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add frontend/src/components/ui/Footer/
+git commit -m "feat(analytics): Footer コンポーネントにプライバシーポリシーリンクを追加"
+```
+
+---
+
+## Task 15: `Footer` を全レイアウトに組み込む
+
+**Files:**
+- Modify: `frontend/src/App.tsx`（`AuthenticatedLayout` / `OptionalAuthLayout` 内に `<Footer />` を挿入）
+- Modify: `frontend/src/App.module.css`（レイアウトを flex にして footer を最下部に固定）
+
+- [ ] **Step 1: `App.tsx` の `AuthenticatedLayout` に Footer を追加**
+
+```tsx
+import { Footer } from './components/ui/Footer/Footer'
+
+// ...
+
+function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
+  const { user, logout } = useAuth()
+
+  if (!user) return <div className={appStyles.loading}>読み込み中...</div>
+
+  return (
+    <div className={appStyles.layoutRoot}>
+      <NavBar user={user} onLogout={() => void logout()} />
+      <div className={appStyles.authenticatedContent}>{children}</div>
+      <Footer />
+      <BottomTabBar />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: `OptionalAuthLayout` にも同様に追加**
+
+```tsx
+function OptionalAuthLayout({ children }: { children: React.ReactNode }) {
+  const { user, isLoading, logout } = useAuth()
+
+  if (isLoading) return <div className={appStyles.loading}>読み込み中...</div>
+
+  if (user) {
+    return (
+      <div className={appStyles.layoutRoot}>
+        <NavBar user={user} onLogout={() => void logout()} />
+        <div className={appStyles.authenticatedContent}>{children}</div>
+        <Footer />
+        <BottomTabBar />
+      </div>
+    )
+  }
+
+  return (
+    <div className={appStyles.layoutRoot}>
+      <nav className={appStyles.publicNav}>
+        <Link to="/login" className={appStyles.logo}>
+          Recolly
+        </Link>
+        <Link to="/login" className={appStyles.loginLink}>
+          ログイン
+        </Link>
+      </nav>
+      <div className={appStyles.authenticatedContent}>{children}</div>
+      <Footer />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: `App.module.css` に `layoutRoot` クラスを追加**
+
+`frontend/src/App.module.css` の末尾に追加:
+
+```css
+.layoutRoot {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+```
+
+- [ ] **Step 4: 既存の MemoryRouter ベースのページテストが壊れないことを確認**
+
+```bash
+cd frontend && npm run test
+```
+
+Expected: 既存全テスト PASS。Footer の追加で壊れるテストがあればそれは `AuthenticatedLayout` をモックしていないはず。個別ページのテストはレイアウトを経由しないので基本影響しない。
+
+- [ ] **Step 5: 型チェック + lint**
+
+```bash
+cd frontend && npm run typecheck && npm run lint
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/App.tsx frontend/src/App.module.css
+git commit -m "feat(analytics): 認証済/オプショナル認証レイアウトに Footer を組み込む"
+```
+
+---
+
+## Task 16: 非認証ページ（LoginPage / SignUpPage / PasswordNewPage / PasswordEditPage / OauthUsernamePage / EmailPromptPage）にも Footer を追加
+
+**Files:**
+- Modify: 上記 6 ページの JSX
+
+これらは `authForm.module.css` 等の独自レイアウトを使っていて `AuthenticatedLayout` を経由しないため、ページ側で `<Footer />` を挿入する必要がある。
+
+- [ ] **Step 1: 対象ページの現状を把握**
+
+```bash
+cd frontend && grep -l "authForm.module" src/pages/
+```
+
+Expected: Login / SignUp / PasswordNew / PasswordEdit / OauthUsername ページがヒット。
+
+- [ ] **Step 2: `LoginPage.tsx` に Footer を追加**
+
+```tsx
+import { Footer } from '../../components/ui/Footer/Footer'
+
+// return の最外 div を差し替え
+return (
+  <>
+    <div className={styles.page}>
+      {/* 既存の中身 */}
+    </div>
+    <Footer />
+  </>
+)
+```
+
+同様のパターンで `SignUpPage.tsx`, `PasswordNewPage.tsx`, `PasswordEditPage.tsx`, `OauthUsernamePage.tsx`, `EmailPromptPage.tsx` にも `<Footer />` を追加する。
+
+- [ ] **Step 3: `authForm.module.css` の `page` クラスが画面いっぱいを占有していないか確認**
+
+```bash
+cd frontend && grep -A 10 "\.page" src/styles/authForm.module.css
+```
+
+`page` が `min-height: 100vh` 等で画面いっぱいなら Footer が画面外に押し出される。必要なら `min-height: 100vh` を `min-height: auto` に変え、外側の wrapper で flex にする。
+
+- [ ] **Step 4: 該当ページのテストが壊れていないことを確認**
+
+```bash
+cd frontend && npm run test -- src/pages/LoginPage src/pages/SignUpPage src/pages/PasswordNewPage src/pages/PasswordEditPage src/pages/OauthUsernamePage src/pages/EmailPromptPage
+```
+
+Expected: 全 PASS。Footer は Link を使っているので、テスト側で MemoryRouter / BrowserRouter が無いと link が壊れる可能性がある。既存テストが Router を wrap していなければ追加する。
+
+- [ ] **Step 5: lint + 型チェック**
+
+```bash
+cd frontend && npm run typecheck && npm run lint
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/pages/LoginPage/ frontend/src/pages/SignUpPage/ frontend/src/pages/PasswordNewPage/ frontend/src/pages/PasswordEditPage/ frontend/src/pages/OauthUsernamePage/ frontend/src/pages/EmailPromptPage/ frontend/src/styles/authForm.module.css
+git commit -m "feat(analytics): 非認証ページに Footer を追加"
+```
+
+---
+
+## Task 17: 最終全体検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: 全体テスト実行**
+
+```bash
+cd frontend && npm run test
+```
+
+Expected: 全テスト PASS。
+
+- [ ] **Step 2: 型チェック**
+
+```bash
+cd frontend && npm run typecheck
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 3: lint**
+
+```bash
+cd frontend && npm run lint
+```
+
+Expected: エラーなし。
+
+- [ ] **Step 4: プロダクションビルド**
+
+```bash
+cd frontend && npm run build
+```
+
+Expected: ビルド成功。バンドルサイズのログを見て posthog-js が含まれている（+ 約 40KB gzipped）ことを確認。
+
+- [ ] **Step 5: バックエンド（念のため）の lint + test が通ることを確認**
+
+```bash
+cd backend && bundle exec rubocop && bundle exec rspec
+```
+
+Expected: エラーなし（このタスクは frontend 限定だが、念のため確認）。
+
+- [ ] **Step 6: 完了コミット（検証系で差分が無ければ不要）**
+
+このタスクは検証のみなので基本的に新規コミットは発生しない。差分が出ていたら push 前に確認する。
+
+---
+
+## Task 18: 動作確認
+
+**Files:** なし
+
+- [ ] **Step 1: 動作確認方法をユーザーに確認する**
+
+`recolly-workflow` の Step 5 のゲート。AskUserQuestion で以下を質問:
+
+1. 手動確認（ブラウザ操作手順を案内）
+2. Playwright MCP で自動確認
+
+- [ ] **Step 2: 選択された方式で動作確認**
+
+手動の場合: 開発サーバーを起動し、以下のフローをユーザーに実行してもらう。
+
+```bash
+cd frontend && npm run dev
+```
+
+確認項目:
+1. `/login` ページを開き、フッターに「プライバシーポリシー」リンクが表示される
+2. リンクをクリックして `/privacy` が開く
+3. 新規登録（email）を実行し、PostHog Live events ページで `signup_completed` が届いているか
+4. ログイン後にダッシュボードで pageview が届くか
+5. 記録を作成して `record_created` + `media_type` が届くか
+6. ログアウトして reset が発火するか（PostHog 側で識別が解除される）
+
+Playwright の場合: 同等のフローを自動テストで実行し、ネットワークタブで PostHog へのリクエストを検証する。
+
+- [ ] **Step 3: 不具合があれば該当 Task に戻って修正**
+
+---
+
+## Task 19: PR 作成・レビュー対応・マージ
+
+**Files:** なし（Git 操作のみ）
+
+- [ ] **Step 1: `superpowers:finishing-a-development-branch` スキルを起動**
+
+```text
+superpowers:finishing-a-development-branch を発動する
+```
+
+スキルの指示に従って push → PR 作成 → 自動レビュー待ち → 対応 → マージ。
+
+- [ ] **Step 2: PR タイトルは Conventional Commits**
+
+例: `feat(analytics): PostHog でプロダクト分析基盤を導入（Phase 1）`
+
+- [ ] **Step 3: PR 本文に Issue #143 をリンク**
+
+`Closes #143` を含める。
+
+- [ ] **Step 4: 自動レビューの指摘に対応（必要なら）**
+
+`recolly-git-rules` スキルの「レビュー対応のフィードバックループ」に従う。
+
+- [ ] **Step 5: マージ判断は IK さん**
+
+IK さんがマージボタンを押す。
+
+---
+
+## Spec Coverage Check
+
+| Spec 要件 | 対応タスク |
+|---|---|
+| posthog-js 依存追加 (§3.1) | Task 1 |
+| 環境変数未設定時の no-op (§3.4) | Task 3 |
+| `$pageview` 自動発火 + SPA 対応 (§3.7) | Task 5, 6 |
+| `$identify` ログイン成功時発火 (§3.5) | Task 7 |
+| `reset` ログアウト時 (§3.5) | Task 7 |
+| `signup_completed` email (§3.5) | Task 8 |
+| `signup_completed` OAuth (§3.5) | Task 9 |
+| `record_created` + `media_type` (§3.5) | Task 10, 11 |
+| プライバシーポリシーページ `/privacy` (§4.4) | Task 12, 13 |
+| フッターからリンク (§4.4) | Task 14, 15, 16 |
+| ユニットテスト (§5.1) | Task 3, 5, 12, 14 |
+| 統合テスト (§5.2) | Task 7, 8, 9, 10, 11 |
+| 手動検証 (§5.3) | Task 18 |
+| 失敗時にも本体動作継続 (§6.2) | Task 3（try/catch） |
+
+---
+
+## Notes / 実装時の注意点
+
+- PostHog の `init` は 1 回だけ呼ぶこと（`main.tsx` で起動時に 1 回）。React StrictMode では `useEffect` が 2 回走るが、`main.tsx` の `initAnalytics` は component の useEffect ではないので影響しない。
+- 開発環境で `.env.local` が空のケースを壊さないこと（`initAnalytics` が no-op）。
+- `posthog-js` のバージョンは最新を使う。将来的な API 変更には ADR-0041 の影響セクションに追記する形で対応する。
+- テストは `vi.mock('posthog-js')` で完全にモック化し、実際のネットワーク通信は発生させない。
+- `React.StrictMode` の 2 重マウントで `capturePageview` が 2 回呼ばれる可能性があるが、これは開発環境限定なので本番には影響しない。気になる場合は初回マウントフラグで抑制する。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "motion": "^12.38.0",
+        "posthog-js": "^1.367.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.1"
@@ -2149,6 +2150,252 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.208.0.tgz",
+      "integrity": "sha512-CjruKY9V6NMssL/T1kAFgzosF1v9o6oeN+aX5JB/C/xPNtmgIJqcXHG7fA82Ou1zCpWGl4lROQUKwUNE1pMCyg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
+      "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-logs-otlp-http": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-logs-otlp-http/-/exporter-logs-otlp-http-0.208.0.tgz",
+      "integrity": "sha512-jOv40Bs9jy9bZVLo/i8FwUiuCvbjWDI+ZW13wimJm4LjnlwJxGgB+N/VWOZUTpM+ah/awXeQqKdNlpLf2EjvYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-exporter-base": "0.208.0",
+        "@opentelemetry/otlp-transformer": "0.208.0",
+        "@opentelemetry/sdk-logs": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.208.0.tgz",
+      "integrity": "sha512-gMd39gIfVb2OgxldxUtOwGJYSH8P1kVFFlJLuut32L6KgUC4gl1dMhn+YC2mGn0bDOiQYSk/uHOdSjuKp58vvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/otlp-transformer": "0.208.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.208.0.tgz",
+      "integrity": "sha512-DCFPY8C6lAQHUNkzcNT9R+qYExvsk6C5Bto2pbNxgicpcSWbe2WHShLxkOxIdNcBiYPdVHv/e7vH7K6TI+C+fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/sdk-logs": "0.208.0",
+        "@opentelemetry/sdk-metrics": "2.2.0",
+        "@opentelemetry/sdk-trace-base": "2.2.0",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.3.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.6.1.tgz",
+      "integrity": "sha512-lID/vxSuKWXM55XhAKNoYXu9Cutoq5hFdkbTdI/zDKQktXzcWBVhNsOkiZFTMU9UtEWuGRNe0HUgmsFldIdxVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.6.1",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+      "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.208.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.208.0.tgz",
+      "integrity": "sha512-QlAyL1jRpOeaqx7/leG1vJMp84g0xKP6gJmfELBpnI4O/9xPX+Hu5m1POk9Kl+veNkyth5t19hRlN6tNY1sjbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.208.0",
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-2.2.0.tgz",
+      "integrity": "sha512-G5KYP6+VJMZzpGipQw7Giif48h6SGQ2PFKEYCybeXJsOCB4fp8azqMAAzE5lnnHK3ZVwYQrgmFbsUJO/zOnwGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.9.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
+      "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/resources": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/resources": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
+      "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.2.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+      "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@oxc-project/types": {
       "version": "0.120.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.120.0.tgz",
@@ -2158,6 +2405,82 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.25.2",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.25.2.tgz",
+      "integrity": "sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==",
+      "license": "MIT"
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.367.0.tgz",
+      "integrity": "sha512-FUcTEAeKhuHKyCcTQPx/sTN3s8S+PusPsiP8T/LrG/T7pDkwMfNZG0/P630JX6fT6qiW0moVvVSsaXgZDJF7wg==",
+      "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
+      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
+      "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
+      "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.10",
@@ -2765,7 +3088,6 @@
       "version": "24.12.0",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -2802,7 +3124,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -3710,6 +4032,17 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.49.0.tgz",
+      "integrity": "sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-js-compat": {
       "version": "3.49.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
@@ -3949,6 +4282,15 @@
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4442,6 +4784,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -6027,6 +6375,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6464,6 +6818,37 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/posthog-js": {
+      "version": "1.367.0",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.367.0.tgz",
+      "integrity": "sha512-jWNwB8XjlVUC9PbGaIlmsyohUDMBrwf7cvLuOY3lIOmWVO3L6VxTE3GZShjxpFKQtmWcPxFbf1hcbct1YCb6xg==",
+      "license": "SEE LICENSE IN LICENSE",
+      "dependencies": {
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/api-logs": "^0.208.0",
+        "@opentelemetry/exporter-logs-otlp-http": "^0.208.0",
+        "@opentelemetry/resources": "^2.2.0",
+        "@opentelemetry/sdk-logs": "^0.208.0",
+        "@posthog/core": "1.25.2",
+        "@posthog/types": "1.367.0",
+        "core-js": "^3.38.1",
+        "dompurify": "^3.3.2",
+        "fflate": "^0.4.8",
+        "preact": "^10.28.2",
+        "query-selector-shadow-dom": "^1.0.1",
+        "web-vitals": "^5.1.0"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6531,6 +6916,30 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
+      "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -6540,6 +6949,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/query-selector-shadow-dom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.1.tgz",
+      "integrity": "sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==",
+      "license": "MIT"
     },
     "node_modules/randombytes": {
       "version": "2.1.0",
@@ -7743,7 +8158,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -8068,6 +8482,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/web-vitals": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-5.2.0.tgz",
+      "integrity": "sha512-i2z98bEmaCqSDiHEDu+gHl/dmR4Q+TxFmG3/13KkMO+o8UxQzCqWaDRCiLgEa41nlO4VpXSI0ASa1xWmO9sBlA==",
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "8.0.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "motion": "^12.38.0",
+    "posthog-js": "^1.367.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.1"

--- a/frontend/src/App.module.css
+++ b/frontend/src/App.module.css
@@ -58,3 +58,15 @@
     padding-bottom: var(--bottom-tab-height);
   }
 }
+
+/* レイアウトルート: フッターを最下部に固定するための flex コンテナ */
+.layoutRoot {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+}
+
+/* authenticatedContent をフレックスアイテムとして伸ばす */
+.layoutRoot .authenticatedContent {
+  flex: 1 1 auto;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { NavBar } from './components/ui/NavBar/NavBar'
 import { BottomTabBar } from './components/ui/BottomTabBar/BottomTabBar'
 import { UpdatePrompt } from './components/ui/UpdatePrompt/UpdatePrompt'
 import { PageviewTracker } from './components/PageviewTracker/PageviewTracker'
+import { Footer } from './components/ui/Footer/Footer'
 import appStyles from './App.module.css'
 
 // ページコンポーネントは全て lazy-load する（code splitting）
@@ -98,11 +99,12 @@ function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   if (!user) return <div className={appStyles.loading}>読み込み中...</div>
 
   return (
-    <>
+    <div className={appStyles.layoutRoot}>
       <NavBar user={user} onLogout={() => void logout()} />
       <div className={appStyles.authenticatedContent}>{children}</div>
+      <Footer />
       <BottomTabBar />
-    </>
+    </div>
   )
 }
 
@@ -114,16 +116,17 @@ function OptionalAuthLayout({ children }: { children: React.ReactNode }) {
 
   if (user) {
     return (
-      <>
+      <div className={appStyles.layoutRoot}>
         <NavBar user={user} onLogout={() => void logout()} />
         <div className={appStyles.authenticatedContent}>{children}</div>
+        <Footer />
         <BottomTabBar />
-      </>
+      </div>
     )
   }
 
   return (
-    <>
+    <div className={appStyles.layoutRoot}>
       <nav className={appStyles.publicNav}>
         <Link to="/login" className={appStyles.logo}>
           Recolly
@@ -133,7 +136,8 @@ function OptionalAuthLayout({ children }: { children: React.ReactNode }) {
         </Link>
       </nav>
       <div className={appStyles.authenticatedContent}>{children}</div>
-    </>
+      <Footer />
+    </div>
   )
 }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -68,6 +68,9 @@ const RecommendationsPage = lazy(() =>
     default: m.RecommendationsPage,
   })),
 )
+const PrivacyPage = lazy(() =>
+  import('./pages/PrivacyPage/PrivacyPage').then((m) => ({ default: m.PrivacyPage })),
+)
 
 // 認証済みならダッシュボードへ、未認証ならログインページへ
 function RootRedirect() {
@@ -160,6 +163,14 @@ function App() {
             <Route path="/password/new" element={<PasswordNewPage />} />
             <Route path="/password/edit" element={<PasswordEditPage />} />
             <Route path="/auth/complete" element={<OauthUsernamePage />} />
+            <Route
+              path="/privacy"
+              element={
+                <OptionalAuthLayout>
+                  <PrivacyPage />
+                </OptionalAuthLayout>
+              }
+            />
             <Route
               path="/dashboard"
               element={

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { ProtectedRoute } from './components/ProtectedRoute/ProtectedRoute'
 import { NavBar } from './components/ui/NavBar/NavBar'
 import { BottomTabBar } from './components/ui/BottomTabBar/BottomTabBar'
 import { UpdatePrompt } from './components/ui/UpdatePrompt/UpdatePrompt'
+import { PageviewTracker } from './components/PageviewTracker/PageviewTracker'
 import appStyles from './App.module.css'
 
 // ページコンポーネントは全て lazy-load する（code splitting）
@@ -142,6 +143,7 @@ function App() {
   return (
     <BrowserRouter>
       <AuthProvider>
+        <PageviewTracker />
         <AnimatePresence>
           {needRefresh && (
             <UpdatePrompt

--- a/frontend/src/components/PageviewTracker/PageviewTracker.test.tsx
+++ b/frontend/src/components/PageviewTracker/PageviewTracker.test.tsx
@@ -1,0 +1,65 @@
+import { render, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../lib/analytics/posthog', () => ({
+  capturePageview: vi.fn(),
+}))
+
+import { capturePageview } from '../../lib/analytics/posthog'
+import { PageviewTracker } from './PageviewTracker'
+
+// ナビゲーション確認用の補助コンポーネント
+function TestNavigator({ to }: { to: string }) {
+  const navigate = useNavigate()
+  return (
+    <button type="button" onClick={() => navigate(to)}>
+      go
+    </button>
+  )
+}
+
+describe('PageviewTracker', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('初回マウント時に現在のパスで capturePageview を呼ぶ', () => {
+    render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <PageviewTracker />
+      </MemoryRouter>,
+    )
+    expect(capturePageview).toHaveBeenCalledWith('/dashboard')
+  })
+
+  it('location 変化で新しいパスを渡して capturePageview を再度呼ぶ', async () => {
+    const user = userEvent.setup()
+    const { getByText } = render(
+      <MemoryRouter initialEntries={['/dashboard']}>
+        <PageviewTracker />
+        <Routes>
+          <Route path="/dashboard" element={<TestNavigator to="/library" />} />
+          <Route path="/library" element={<div>library</div>} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    vi.mocked(capturePageview).mockClear()
+    await user.click(getByText('go'))
+
+    await waitFor(() => {
+      expect(capturePageview).toHaveBeenCalledWith('/library')
+    })
+  })
+
+  it('search パラメータも pathname に結合して送る', () => {
+    render(
+      <MemoryRouter initialEntries={['/search?q=hunter']}>
+        <PageviewTracker />
+      </MemoryRouter>,
+    )
+    expect(capturePageview).toHaveBeenCalledWith('/search?q=hunter')
+  })
+})

--- a/frontend/src/components/PageviewTracker/PageviewTracker.tsx
+++ b/frontend/src/components/PageviewTracker/PageviewTracker.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react'
+import { useLocation } from 'react-router-dom'
+import { capturePageview } from '../../lib/analytics/posthog'
+
+/**
+ * React Router の location 変化を監視して PostHog に $pageview を送る。
+ *
+ * PostHog SDK の capture_pageview は初回ロードしか拾えないので、
+ * SPA 遷移ではここで手動発火する。初回マウント時もこの useEffect が走るため、
+ * SDK 側の自動 pageview は init 時に無効化してある。
+ *
+ * BrowserRouter の子孫として配置する必要がある（useLocation を使うため）。
+ */
+export function PageviewTracker(): null {
+  const location = useLocation()
+
+  useEffect(() => {
+    capturePageview(location.pathname + location.search)
+  }, [location.pathname, location.search])
+
+  return null
+}

--- a/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
+++ b/frontend/src/components/ProtectedRoute/ProtectedRoute.test.tsx
@@ -41,7 +41,20 @@ describe('ProtectedRoute', () => {
     // セッション確認: 認証済み
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ user: { id: 1, username: 'test', email: 'test@example.com' } }),
+      json: () =>
+        Promise.resolve({
+          user: {
+            id: 1,
+            username: 'test',
+            email: 'test@example.com',
+            avatar_url: null,
+            bio: null,
+            created_at: '2026-04-01T00:00:00Z',
+            has_password: true,
+            providers: [],
+            email_missing: false,
+          },
+        }),
     })
 
     render(

--- a/frontend/src/components/ui/Footer/Footer.module.css
+++ b/frontend/src/components/ui/Footer/Footer.module.css
@@ -1,0 +1,37 @@
+.footer {
+  border-top: 1px solid var(--color-border-light);
+  background: var(--color-bg-white);
+  padding: var(--spacing-md) var(--spacing-lg);
+  margin-top: auto;
+}
+
+.inner {
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  font-size: var(--font-size-label);
+  color: var(--color-text-muted);
+}
+
+.brand {
+  font-weight: var(--font-weight-medium);
+}
+
+.nav {
+  display: flex;
+  gap: var(--spacing-md);
+}
+
+.link {
+  color: var(--color-text-muted);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.link:hover {
+  color: var(--color-text);
+  text-decoration: underline;
+}

--- a/frontend/src/components/ui/Footer/Footer.test.tsx
+++ b/frontend/src/components/ui/Footer/Footer.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { Footer } from './Footer'
+
+describe('Footer', () => {
+  it('プライバシーポリシーへのリンクを含む', () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    )
+    const link = screen.getByRole('link', { name: /プライバシーポリシー/ })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', '/privacy')
+  })
+
+  it('Recolly のブランド表記を含む', () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    )
+    expect(screen.getByText(/Recolly/)).toBeInTheDocument()
+  })
+
+  it('contentinfo ロールとして認識される (アクセシビリティ)', () => {
+    render(
+      <MemoryRouter>
+        <Footer />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/ui/Footer/Footer.tsx
+++ b/frontend/src/components/ui/Footer/Footer.tsx
@@ -1,0 +1,25 @@
+import { Link } from 'react-router-dom'
+import styles from './Footer.module.css'
+
+/**
+ * 全ページ共通のフッター。
+ *
+ * Cookie 同意バナーを実装しない方針のため、プライバシーポリシーへの導線を
+ * 常に露出する目的で配置する。
+ *
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 4.4 節
+ */
+export function Footer() {
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.inner}>
+        <span className={styles.brand}>© Recolly</span>
+        <nav className={styles.nav}>
+          <Link to="/privacy" className={styles.link}>
+            プライバシーポリシー
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  )
+}

--- a/frontend/src/contexts/AuthContext.test.tsx
+++ b/frontend/src/contexts/AuthContext.test.tsx
@@ -9,8 +9,18 @@ import { useAuth } from './useAuth'
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
+// PostHog ラッパーをモック化（実際のネットワーク通信を発生させない）
+vi.mock('../lib/analytics/posthog', () => ({
+  identifyUser: vi.fn(),
+  resetAnalytics: vi.fn(),
+}))
+
+import { identifyUser, resetAnalytics } from '../lib/analytics/posthog'
+
 beforeEach(() => {
   mockFetch.mockReset()
+  vi.mocked(identifyUser).mockClear()
+  vi.mocked(resetAnalytics).mockClear()
 })
 
 // AuthContextの値を表示するテスト用コンポーネント
@@ -56,7 +66,19 @@ describe('AuthContext', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
-        Promise.resolve({ user: { id: 1, username: 'testuser', email: 'test@example.com' } }),
+        Promise.resolve({
+          user: {
+            id: 1,
+            username: 'testuser',
+            email: 'test@example.com',
+            avatar_url: null,
+            bio: null,
+            created_at: '2026-04-01T00:00:00Z',
+            has_password: true,
+            providers: [],
+            email_missing: false,
+          },
+        }),
     })
 
     renderWithProvider()
@@ -73,7 +95,19 @@ describe('AuthContext', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
-        Promise.resolve({ user: { id: 1, username: 'testuser', email: 'test@example.com' } }),
+        Promise.resolve({
+          user: {
+            id: 1,
+            username: 'testuser',
+            email: 'test@example.com',
+            avatar_url: null,
+            bio: null,
+            created_at: '2026-04-01T00:00:00Z',
+            has_password: true,
+            providers: [],
+            email_missing: false,
+          },
+        }),
     })
 
     renderWithProvider()
@@ -92,6 +126,121 @@ describe('AuthContext', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('authenticated')).toHaveTextContent('false')
+    })
+  })
+
+  describe('analytics integration', () => {
+    it('セッション復帰時 (email 登録) に identifyUser が email で呼ばれる', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            user: {
+              id: 7,
+              username: 'alice',
+              email: 'alice@example.com',
+              avatar_url: null,
+              bio: null,
+              created_at: '2026-04-01T00:00:00Z',
+              has_password: true,
+              providers: [],
+              email_missing: false,
+            },
+          }),
+      })
+
+      renderWithProvider()
+
+      await waitFor(() => {
+        expect(identifyUser).toHaveBeenCalledWith({
+          id: 7,
+          signup_method: 'email',
+          signup_date: '2026-04-01T00:00:00Z',
+        })
+      })
+    })
+
+    it('セッション復帰時 (Google 連携済) に identifyUser が google で呼ばれる', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            user: {
+              id: 99,
+              username: 'bob',
+              email: 'bob@example.com',
+              avatar_url: null,
+              bio: null,
+              created_at: '2026-03-15T00:00:00Z',
+              has_password: false,
+              providers: ['google_oauth2'],
+              email_missing: false,
+            },
+          }),
+      })
+
+      renderWithProvider()
+
+      await waitFor(() => {
+        expect(identifyUser).toHaveBeenCalledWith({
+          id: 99,
+          signup_method: 'google',
+          signup_date: '2026-03-15T00:00:00Z',
+        })
+      })
+    })
+
+    it('ログアウト時に resetAnalytics が呼ばれる', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            user: {
+              id: 1,
+              username: 'testuser',
+              email: 'test@example.com',
+              avatar_url: null,
+              bio: null,
+              created_at: '2026-04-01T00:00:00Z',
+              has_password: true,
+              providers: [],
+              email_missing: false,
+            },
+          }),
+      })
+
+      renderWithProvider()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('authenticated')).toHaveTextContent('true')
+      })
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ message: 'ログアウトしました' }),
+      })
+
+      await userEvent.click(screen.getByText('ログアウト'))
+
+      await waitFor(() => {
+        expect(resetAnalytics).toHaveBeenCalled()
+      })
+    })
+
+    it('未ログイン状態で初回ロード完了しても identifyUser / resetAnalytics は呼ばれない', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 401,
+        json: () => Promise.resolve({ error: 'ログインが必要です' }),
+      })
+
+      renderWithProvider()
+
+      await waitFor(() => {
+        expect(screen.getByTestId('loading')).toHaveTextContent('false')
+      })
+      expect(identifyUser).not.toHaveBeenCalled()
+      expect(resetAnalytics).not.toHaveBeenCalled()
     })
   })
 })

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,15 +1,28 @@
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { authApi, ApiError } from '../lib/api'
 import type { User } from '../lib/types'
 import { AuthContext } from './authContextValue'
+import { identifyUser, resetAnalytics } from '../lib/analytics/posthog'
 
 export type { AuthContextValue } from './authContextValue'
 export { AuthContext } from './authContextValue'
 
+// User.providers から signup_method を導出する。
+// Google 連携済みかつパスワード未設定なら 'google' とみなし、それ以外は 'email'。
+// (両方に紐付いている場合は email 優先 = 直接メール登録も行ったユーザーとして扱う)
+function deriveSignupMethod(user: User): 'email' | 'google' {
+  if (!user.has_password && user.providers.includes('google_oauth2')) {
+    return 'google'
+  }
+  return 'email'
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  // 直前に identify したユーザー ID。同一ユーザーで重複 identify しないための記録
+  const lastIdentifiedIdRef = useRef<number | null>(null)
 
   // 初回ロード時にセッション確認
   useEffect(() => {
@@ -19,6 +32,26 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       .catch(() => setUser(null))
       .finally(() => setIsLoading(false))
   }, [])
+
+  // user state の変化を監視して PostHog の identify / reset を発火。
+  // login / signup / OAuth complete / initial session 復帰 / logout の全パスで
+  // 確実に 1 回ずつ走るよう、user state 変化の単一ポイントで扱う。
+  useEffect(() => {
+    if (isLoading) return
+    if (user) {
+      if (lastIdentifiedIdRef.current === user.id) return
+      lastIdentifiedIdRef.current = user.id
+      identifyUser({
+        id: user.id,
+        signup_method: deriveSignupMethod(user),
+        signup_date: user.created_at,
+      })
+    } else if (lastIdentifiedIdRef.current !== null) {
+      // 直前に identify していたユーザーがログアウトした場合のみ reset する
+      lastIdentifiedIdRef.current = null
+      resetAnalytics()
+    }
+  }, [user, isLoading])
 
   const login = useCallback(async (email: string, password: string) => {
     const data = await authApi.login(email, password)

--- a/frontend/src/lib/analytics/events.ts
+++ b/frontend/src/lib/analytics/events.ts
@@ -1,0 +1,22 @@
+/**
+ * PostHog に送信するイベント名の定数定義。
+ * 文字列リテラルの typo を防ぐため、発火側は必ずこの定数経由で指定する。
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 2.1 節
+ */
+export const ANALYTICS_EVENTS = {
+  PAGEVIEW: '$pageview',
+  SIGNUP_COMPLETED: 'signup_completed',
+  RECORD_CREATED: 'record_created',
+} as const
+
+export type AnalyticsEventName = (typeof ANALYTICS_EVENTS)[keyof typeof ANALYTICS_EVENTS]
+
+/** signup_completed のプロパティ */
+export type SignupCompletedProps = {
+  method: 'email' | 'google'
+}
+
+/** record_created のプロパティ */
+export type RecordCreatedProps = {
+  media_type: 'anime' | 'movie' | 'drama' | 'book' | 'manga' | 'game'
+}

--- a/frontend/src/lib/analytics/posthog.test.ts
+++ b/frontend/src/lib/analytics/posthog.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// posthog-js をモック化。import より前に vi.mock を呼ぶ必要がある
+vi.mock('posthog-js', () => ({
+  default: {
+    init: vi.fn(),
+    identify: vi.fn(),
+    reset: vi.fn(),
+    capture: vi.fn(),
+  },
+}))
+
+import posthog from 'posthog-js'
+import {
+  initAnalytics,
+  identifyUser,
+  resetAnalytics,
+  captureEvent,
+  capturePageview,
+  __resetForTest,
+} from './posthog'
+
+describe('analytics/posthog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    __resetForTest()
+  })
+
+  describe('initAnalytics', () => {
+    it('key と host が両方指定されたとき posthog.init を呼ぶ', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      expect(posthog.init).toHaveBeenCalledWith('phc_test', {
+        api_host: 'https://us.i.posthog.com',
+        capture_pageview: false,
+        persistence: 'localStorage+cookie',
+      })
+    })
+
+    it('key が未設定なら posthog.init を呼ばない', () => {
+      initAnalytics({ key: '', host: 'https://us.i.posthog.com' })
+      expect(posthog.init).not.toHaveBeenCalled()
+    })
+
+    it('host が未設定なら posthog.init を呼ばない', () => {
+      initAnalytics({ key: 'phc_test', host: '' })
+      expect(posthog.init).not.toHaveBeenCalled()
+    })
+
+    it('key と host が undefined でも例外を投げない', () => {
+      expect(() => initAnalytics({ key: undefined, host: undefined })).not.toThrow()
+      expect(posthog.init).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('identifyUser', () => {
+    it('未 init 状態では posthog.identify を呼ばない（例外も投げない）', () => {
+      expect(() =>
+        identifyUser({
+          id: 1,
+          signup_method: 'email',
+          signup_date: '2026-04-13T00:00:00Z',
+        }),
+      ).not.toThrow()
+      expect(posthog.identify).not.toHaveBeenCalled()
+    })
+
+    it('init 済みなら posthog.identify を distinct_id と $set プロパティ付きで呼ぶ', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      identifyUser({
+        id: 42,
+        signup_method: 'google',
+        signup_date: '2026-04-13T00:00:00Z',
+      })
+      expect(posthog.identify).toHaveBeenCalledWith('42', {
+        signup_method: 'google',
+        signup_date: '2026-04-13T00:00:00Z',
+      })
+    })
+  })
+
+  describe('resetAnalytics', () => {
+    it('init 済みなら posthog.reset を呼ぶ', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      resetAnalytics()
+      expect(posthog.reset).toHaveBeenCalled()
+    })
+
+    it('未 init 状態では posthog.reset を呼ばない（例外も投げない）', () => {
+      expect(() => resetAnalytics()).not.toThrow()
+      expect(posthog.reset).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('captureEvent', () => {
+    it('init 済みなら posthog.capture にイベント名とプロパティを渡す', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      captureEvent('signup_completed', { method: 'email' })
+      expect(posthog.capture).toHaveBeenCalledWith('signup_completed', { method: 'email' })
+    })
+
+    it('未 init 状態では posthog.capture を呼ばない（例外も投げない）', () => {
+      expect(() => captureEvent('signup_completed', { method: 'email' })).not.toThrow()
+      expect(posthog.capture).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('capturePageview', () => {
+    it('init 済みなら $pageview を $current_url 付きで posthog.capture に渡す', () => {
+      initAnalytics({ key: 'phc_test', host: 'https://us.i.posthog.com' })
+      capturePageview('/dashboard')
+      expect(posthog.capture).toHaveBeenCalledWith('$pageview', {
+        $current_url: '/dashboard',
+      })
+    })
+
+    it('未 init 状態では posthog.capture を呼ばない（例外も投げない）', () => {
+      expect(() => capturePageview('/dashboard')).not.toThrow()
+      expect(posthog.capture).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/frontend/src/lib/analytics/posthog.ts
+++ b/frontend/src/lib/analytics/posthog.ts
@@ -1,0 +1,91 @@
+import posthog from 'posthog-js'
+import { ANALYTICS_EVENTS, type AnalyticsEventName } from './events'
+
+/**
+ * PostHog のラッパー。
+ *
+ * 設計:
+ * - 環境変数が未設定ならサイレントに no-op（ローカル開発で .env.local が空でも壊さない）
+ * - init / capture が失敗しても例外は握りつぶして console.warn のみ（Recolly 本体の動作を止めない）
+ * - SDK の自動 pageview は無効化し、React Router の location 変化時に手動発火する
+ *
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 3.4 節
+ */
+
+let initialized = false
+
+type InitOptions = {
+  key: string | undefined
+  host: string | undefined
+}
+
+export function initAnalytics({ key, host }: InitOptions): void {
+  if (!key || !host) {
+    // 環境変数未設定時は何もしない
+    return
+  }
+  try {
+    posthog.init(key, {
+      api_host: host,
+      // SDK の自動 pageview を無効化。SPA 遷移と初回ロードの両方を手動制御するため
+      capture_pageview: false,
+      persistence: 'localStorage+cookie',
+    })
+    initialized = true
+  } catch (error) {
+    console.warn('[analytics] PostHog init failed:', error)
+  }
+}
+
+export type IdentifyPayload = {
+  id: number
+  signup_method: 'email' | 'google'
+  signup_date: string
+}
+
+export function identifyUser(payload: IdentifyPayload): void {
+  if (!initialized) return
+  try {
+    posthog.identify(String(payload.id), {
+      signup_method: payload.signup_method,
+      signup_date: payload.signup_date,
+    })
+  } catch (error) {
+    console.warn('[analytics] identify failed:', error)
+  }
+}
+
+export function resetAnalytics(): void {
+  if (!initialized) return
+  try {
+    posthog.reset()
+  } catch (error) {
+    console.warn('[analytics] reset failed:', error)
+  }
+}
+
+export function captureEvent<P extends Record<string, unknown>>(
+  eventName: AnalyticsEventName,
+  properties: P,
+): void {
+  if (!initialized) return
+  try {
+    posthog.capture(eventName, properties)
+  } catch (error) {
+    console.warn('[analytics] capture failed:', error)
+  }
+}
+
+export function capturePageview(currentUrl: string): void {
+  if (!initialized) return
+  try {
+    posthog.capture(ANALYTICS_EVENTS.PAGEVIEW, { $current_url: currentUrl })
+  } catch (error) {
+    console.warn('[analytics] pageview capture failed:', error)
+  }
+}
+
+/** テスト用: 内部状態をリセットする（プロダクションコードからは呼ばない） */
+export function __resetForTest(): void {
+  initialized = false
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,14 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { initAnalytics } from './lib/analytics/posthog'
+
+// PostHog 初期化。環境変数が未設定ならサイレントに no-op
+// (ローカル開発で .env.local が空でも壊さない設計)
+initAnalytics({
+  key: import.meta.env.VITE_POSTHOG_KEY as string | undefined,
+  host: import.meta.env.VITE_POSTHOG_HOST as string | undefined,
+})
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/frontend/src/pages/EmailPromptPage/EmailPromptPage.tsx
+++ b/frontend/src/pages/EmailPromptPage/EmailPromptPage.tsx
@@ -7,6 +7,7 @@ import { Typography } from '../../components/ui/Typography/Typography'
 import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { Footer } from '../../components/ui/Footer/Footer'
 import styles from '../../styles/authForm.module.css'
 
 export function EmailPromptPage() {
@@ -41,31 +42,34 @@ export function EmailPromptPage() {
   }
 
   return (
-    <div className={styles.page}>
-      <div className={styles.card}>
-        <Typography variant="h2">メールアドレスを設定</Typography>
-        <Divider />
-        <form className={styles.form} onSubmit={handleSubmit}>
-          <FormInput
-            label="メールアドレス"
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoComplete="email"
-          />
-          {error && <p className={styles.error}>{error}</p>}
-          <Button variant="primary" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? '設定中...' : '設定する'}
-          </Button>
-        </form>
-        <div className={styles.link}>
-          <button type="button" className={styles.skipButton} onClick={handleSkip}>
-            あとで設定する
-          </button>
+    <div className={styles.layout}>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <Typography variant="h2">メールアドレスを設定</Typography>
+          <Divider />
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <FormInput
+              label="メールアドレス"
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+            />
+            {error && <p className={styles.error}>{error}</p>}
+            <Button variant="primary" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '設定中...' : '設定する'}
+            </Button>
+          </form>
+          <div className={styles.link}>
+            <button type="button" className={styles.skipButton} onClick={handleSkip}>
+              あとで設定する
+            </button>
+          </div>
         </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/LoginPage/LoginPage.test.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.test.tsx
@@ -48,7 +48,20 @@ describe('LoginPage', () => {
     // ログインAPI成功
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: () => Promise.resolve({ user: { id: 1, username: 'test', email: 'test@example.com' } }),
+      json: () =>
+        Promise.resolve({
+          user: {
+            id: 1,
+            username: 'test',
+            email: 'test@example.com',
+            avatar_url: null,
+            bio: null,
+            created_at: '2026-04-01T00:00:00Z',
+            has_password: true,
+            providers: [],
+            email_missing: false,
+          },
+        }),
     })
 
     await user.type(await screen.findByLabelText('メールアドレス'), 'test@example.com')

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { OAuthButtons } from '../../components/OAuthButtons/OAuthButtons'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { Footer } from '../../components/ui/Footer/Footer'
 import styles from '../../styles/authForm.module.css'
 
 export function LoginPage() {
@@ -62,97 +63,100 @@ export function LoginPage() {
   }
 
   return (
-    <div className={styles.page}>
-      <div className={styles.card}>
-        <Typography variant="h2">ログイン</Typography>
-        <Divider />
-        {successMessage && <p className={styles.success}>{successMessage}</p>}
-        <form id="email-login-form" className={styles.form} onSubmit={handleSubmit}>
-          <FormInput
-            label="メールアドレス"
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoComplete="email"
-          />
-          <FormInput
-            label="パスワード"
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            autoComplete="current-password"
-          />
-          {error && <p className={styles.error}>{error}</p>}
-          {isUnauthorized && (
-            <div className={styles.hintCards}>
-              <Link to="/password/new" className={styles.hintCard}>
-                <span className={styles.hintIcon}>
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M15 7a2 2 0 0 1 2 2m4 0a6 6 0 0 1-7.74 5.74L11 17H9v2H7v2H4a1 1 0 0 1-1-1v-2.59a1 1 0 0 1 .29-.7l6.97-6.97A6 6 0 0 1 21 9z" />
-                  </svg>
-                </span>
-                <span className={styles.hintText}>
-                  <span className={styles.hintTitle}>パスワードを再設定する</span>
-                  <span className={styles.hintDesc}>メールでリセットリンクを送ります</span>
-                </span>
-                <span className={styles.hintArrow}>›</span>
-              </Link>
-              <div className={styles.hintCard}>
-                <span className={styles.hintIcon}>
-                  <svg
-                    viewBox="0 0 24 24"
-                    fill="none"
-                    stroke="currentColor"
-                    strokeWidth="2"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  >
-                    <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
-                    <polyline points="10 17 15 12 10 7" />
-                    <line x1="15" y1="12" x2="3" y2="12" />
-                  </svg>
-                </span>
-                <span className={styles.hintText}>
-                  <span className={styles.hintTitle}>Google でログインしてみる</span>
-                  <span className={styles.hintDesc}>
-                    Google で登録していれば下のボタンからどうぞ
+    <div className={styles.layout}>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <Typography variant="h2">ログイン</Typography>
+          <Divider />
+          {successMessage && <p className={styles.success}>{successMessage}</p>}
+          <form id="email-login-form" className={styles.form} onSubmit={handleSubmit}>
+            <FormInput
+              label="メールアドレス"
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+            />
+            <FormInput
+              label="パスワード"
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+            />
+            {error && <p className={styles.error}>{error}</p>}
+            {isUnauthorized && (
+              <div className={styles.hintCards}>
+                <Link to="/password/new" className={styles.hintCard}>
+                  <span className={styles.hintIcon}>
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M15 7a2 2 0 0 1 2 2m4 0a6 6 0 0 1-7.74 5.74L11 17H9v2H7v2H4a1 1 0 0 1-1-1v-2.59a1 1 0 0 1 .29-.7l6.97-6.97A6 6 0 0 1 21 9z" />
+                    </svg>
                   </span>
-                </span>
+                  <span className={styles.hintText}>
+                    <span className={styles.hintTitle}>パスワードを再設定する</span>
+                    <span className={styles.hintDesc}>メールでリセットリンクを送ります</span>
+                  </span>
+                  <span className={styles.hintArrow}>›</span>
+                </Link>
+                <div className={styles.hintCard}>
+                  <span className={styles.hintIcon}>
+                    <svg
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
+                      <path d="M15 3h4a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2h-4" />
+                      <polyline points="10 17 15 12 10 7" />
+                      <line x1="15" y1="12" x2="3" y2="12" />
+                    </svg>
+                  </span>
+                  <span className={styles.hintText}>
+                    <span className={styles.hintTitle}>Google でログインしてみる</span>
+                    <span className={styles.hintDesc}>
+                      Google で登録していれば下のボタンからどうぞ
+                    </span>
+                  </span>
+                </div>
               </div>
-            </div>
-          )}
-          <Button variant="primary" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? 'ログイン中...' : 'ログイン'}
-          </Button>
-        </form>
-        <OAuthButtons
-          onScrollToEmailForm={() => {
-            const form = document.getElementById('email-login-form')
-            if (form) {
-              form.scrollIntoView({ behavior: 'smooth' })
-              const emailInput = form.querySelector<HTMLInputElement>('input[type="email"]')
-              emailInput?.focus({ preventScroll: true })
-            }
-          }}
-        />
-        <div className={styles.link}>
-          <Link to="/password/new">パスワードをお忘れですか？</Link>
-        </div>
-        <div className={styles.link}>
-          <Link to="/signup">アカウントを作成</Link>
+            )}
+            <Button variant="primary" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'ログイン中...' : 'ログイン'}
+            </Button>
+          </form>
+          <OAuthButtons
+            onScrollToEmailForm={() => {
+              const form = document.getElementById('email-login-form')
+              if (form) {
+                form.scrollIntoView({ behavior: 'smooth' })
+                const emailInput = form.querySelector<HTMLInputElement>('input[type="email"]')
+                emailInput?.focus({ preventScroll: true })
+              }
+            }}
+          />
+          <div className={styles.link}>
+            <Link to="/password/new">パスワードをお忘れですか？</Link>
+          </div>
+          <div className={styles.link}>
+            <Link to="/signup">アカウントを作成</Link>
+          </div>
         </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx
+++ b/frontend/src/pages/OauthUsernamePage/OauthUsernamePage.test.tsx
@@ -38,6 +38,13 @@ vi.mock('../../lib/api', () => ({
   },
 }))
 
+// PostHog ラッパーをモック化
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+}))
+
+import { captureEvent } from '../../lib/analytics/posthog'
+
 beforeEach(() => {
   vi.clearAllMocks()
 })
@@ -102,6 +109,28 @@ describe('OauthUsernamePage', () => {
       expect(mockCompleteRegistration).toHaveBeenCalledWith('testuser')
       expect(mockSetUser).toHaveBeenCalled()
       expect(mockNavigate).toHaveBeenCalledWith('/auth/email-setup', { replace: true })
+    })
+  })
+
+  it('登録完了時に signup_completed イベントを method=google で発火する', async () => {
+    mockCompleteRegistration.mockResolvedValue({
+      user: {
+        id: 42,
+        username: 'alice',
+        email: 'alice@example.com',
+        email_missing: false,
+        providers: ['google_oauth2'],
+      },
+    })
+
+    renderPage()
+    const user = userEvent.setup()
+
+    await user.type(screen.getByLabelText('ユーザー名'), 'alice')
+    await user.click(screen.getByRole('button', { name: '登録する' }))
+
+    await waitFor(() => {
+      expect(captureEvent).toHaveBeenCalledWith('signup_completed', { method: 'google' })
     })
   })
 })

--- a/frontend/src/pages/OauthUsernamePage/OauthUsernamePage.tsx
+++ b/frontend/src/pages/OauthUsernamePage/OauthUsernamePage.tsx
@@ -7,6 +7,8 @@ import { Typography } from '../../components/ui/Typography/Typography'
 import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
 import styles from '../../styles/authForm.module.css'
 
 export function OauthUsernamePage() {
@@ -24,6 +26,9 @@ export function OauthUsernamePage() {
     try {
       const response = await oauthApi.completeRegistration(username)
       setUser(response.user)
+      // OAuth 新規登録完了イベント（method: google）
+      // このページは Google OAuth 経由の新規ユーザーだけが通るため method 固定で良い
+      captureEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method: 'google' })
 
       if (response.user.email_missing) {
         navigate('/auth/email-setup', { replace: true })

--- a/frontend/src/pages/OauthUsernamePage/OauthUsernamePage.tsx
+++ b/frontend/src/pages/OauthUsernamePage/OauthUsernamePage.tsx
@@ -7,6 +7,7 @@ import { Typography } from '../../components/ui/Typography/Typography'
 import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { Footer } from '../../components/ui/Footer/Footer'
 import { captureEvent } from '../../lib/analytics/posthog'
 import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
 import styles from '../../styles/authForm.module.css'
@@ -47,28 +48,31 @@ export function OauthUsernamePage() {
   }
 
   return (
-    <div className={styles.page}>
-      <div className={styles.card}>
-        <Typography variant="h2">ユーザー名を設定</Typography>
-        <Divider />
-        <form className={styles.form} onSubmit={handleSubmit}>
-          <FormInput
-            label="ユーザー名"
-            id="username"
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-            minLength={2}
-            maxLength={30}
-            autoComplete="username"
-          />
-          {error && <p className={styles.error}>{error}</p>}
-          <Button variant="primary" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? '登録中...' : '登録する'}
-          </Button>
-        </form>
+    <div className={styles.layout}>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <Typography variant="h2">ユーザー名を設定</Typography>
+          <Divider />
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <FormInput
+              label="ユーザー名"
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              minLength={2}
+              maxLength={30}
+              autoComplete="username"
+            />
+            {error && <p className={styles.error}>{error}</p>}
+            <Button variant="primary" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '登録中...' : '登録する'}
+            </Button>
+          </form>
+        </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/PasswordEditPage/PasswordEditPage.tsx
+++ b/frontend/src/pages/PasswordEditPage/PasswordEditPage.tsx
@@ -6,6 +6,7 @@ import { Typography } from '../../components/ui/Typography/Typography'
 import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { Footer } from '../../components/ui/Footer/Footer'
 import styles from '../../styles/authForm.module.css'
 
 const MIN_PASSWORD_LENGTH = 6
@@ -55,45 +56,48 @@ export function PasswordEditPage() {
   }
 
   return (
-    <div className={styles.page}>
-      <div className={styles.card}>
-        <Typography variant="h2">新しいパスワードを設定</Typography>
-        <Divider />
-        <form className={styles.form} onSubmit={handleSubmit}>
-          <FormInput
-            label="新しいパスワード"
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            minLength={MIN_PASSWORD_LENGTH}
-            autoComplete="new-password"
-          />
-          <FormInput
-            label="新しいパスワード（確認）"
-            id="passwordConfirmation"
-            type="password"
-            value={passwordConfirmation}
-            onChange={(e) => setPasswordConfirmation(e.target.value)}
-            required
-            minLength={MIN_PASSWORD_LENGTH}
-            autoComplete="new-password"
-          />
-          {tokenInvalid && (
-            <div className={styles.warningBanner}>
-              <p>リンクが無効または期限切れです。再度リセットを申請してください。</p>
-              <p>
-                <Link to="/password/new">パスワードリセットを再申請</Link>
-              </p>
-            </div>
-          )}
-          {error && <p className={styles.error}>{error}</p>}
-          <Button variant="primary" type="submit" disabled={!isValid || isSubmitting}>
-            {isSubmitting ? '更新中...' : 'パスワードを更新'}
-          </Button>
-        </form>
+    <div className={styles.layout}>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <Typography variant="h2">新しいパスワードを設定</Typography>
+          <Divider />
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <FormInput
+              label="新しいパスワード"
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              autoComplete="new-password"
+            />
+            <FormInput
+              label="新しいパスワード（確認）"
+              id="passwordConfirmation"
+              type="password"
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              required
+              minLength={MIN_PASSWORD_LENGTH}
+              autoComplete="new-password"
+            />
+            {tokenInvalid && (
+              <div className={styles.warningBanner}>
+                <p>リンクが無効または期限切れです。再度リセットを申請してください。</p>
+                <p>
+                  <Link to="/password/new">パスワードリセットを再申請</Link>
+                </p>
+              </div>
+            )}
+            {error && <p className={styles.error}>{error}</p>}
+            <Button variant="primary" type="submit" disabled={!isValid || isSubmitting}>
+              {isSubmitting ? '更新中...' : 'パスワードを更新'}
+            </Button>
+          </form>
+        </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/PasswordNewPage/PasswordNewPage.tsx
+++ b/frontend/src/pages/PasswordNewPage/PasswordNewPage.tsx
@@ -6,6 +6,7 @@ import { Typography } from '../../components/ui/Typography/Typography'
 import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { Footer } from '../../components/ui/Footer/Footer'
 import styles from '../../styles/authForm.module.css'
 
 export function PasswordNewPage() {
@@ -34,37 +35,40 @@ export function PasswordNewPage() {
   }
 
   return (
-    <div className={styles.page}>
-      <div className={styles.card}>
-        <Typography variant="h2">パスワードをリセット</Typography>
-        <Divider />
-        {submitted ? (
-          <p className={styles.success}>
-            パスワードリセットの手順をメールをお送りしました。
-            <br />
-            メールをご確認ください。
-          </p>
-        ) : (
-          <form className={styles.form} onSubmit={handleSubmit}>
-            <FormInput
-              label="メールアドレス"
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              autoComplete="email"
-            />
-            {error && <p className={styles.error}>{error}</p>}
-            <Button variant="primary" type="submit" disabled={isSubmitting}>
-              {isSubmitting ? '送信中...' : 'リセットメールを送信'}
-            </Button>
-          </form>
-        )}
-        <div className={styles.link}>
-          <Link to="/login">ログインに戻る</Link>
+    <div className={styles.layout}>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <Typography variant="h2">パスワードをリセット</Typography>
+          <Divider />
+          {submitted ? (
+            <p className={styles.success}>
+              パスワードリセットの手順をメールをお送りしました。
+              <br />
+              メールをご確認ください。
+            </p>
+          ) : (
+            <form className={styles.form} onSubmit={handleSubmit}>
+              <FormInput
+                label="メールアドレス"
+                id="email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+              />
+              {error && <p className={styles.error}>{error}</p>}
+              <Button variant="primary" type="submit" disabled={isSubmitting}>
+                {isSubmitting ? '送信中...' : 'リセットメールを送信'}
+              </Button>
+            </form>
+          )}
+          <div className={styles.link}>
+            <Link to="/login">ログインに戻る</Link>
+          </div>
         </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/PrivacyPage/PrivacyPage.module.css
+++ b/frontend/src/pages/PrivacyPage/PrivacyPage.module.css
@@ -1,0 +1,20 @@
+.page {
+  min-height: 100%;
+  padding: var(--spacing-xl) var(--spacing-md);
+  color: var(--color-text);
+}
+
+.content {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.section {
+  margin-top: var(--spacing-xl);
+}
+
+.list {
+  margin: var(--spacing-md) 0;
+  padding-left: var(--spacing-lg);
+  line-height: 1.8;
+}

--- a/frontend/src/pages/PrivacyPage/PrivacyPage.test.tsx
+++ b/frontend/src/pages/PrivacyPage/PrivacyPage.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { PrivacyPage } from './PrivacyPage'
+
+describe('PrivacyPage', () => {
+  it('タイトルが表示される', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getByRole('heading', { name: /プライバシーポリシー/ })).toBeInTheDocument()
+  })
+
+  it('PostHog を使用していることを明記している', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getAllByText(/PostHog/).length).toBeGreaterThan(0)
+  })
+
+  it('PII を送信しない方針を明記している (パスワード or 感想本文)', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    // 送信しない情報リストに PII が含まれているか
+    expect(screen.getByText(/パスワード/)).toBeInTheDocument()
+    expect(screen.getByText(/感想本文/)).toBeInTheDocument()
+  })
+
+  it('オプトアウト方法について言及している', () => {
+    render(
+      <MemoryRouter>
+        <PrivacyPage />
+      </MemoryRouter>,
+    )
+    expect(screen.getAllByText(/オプトアウト|計測を拒否|拒否したい/).length).toBeGreaterThan(0)
+  })
+})

--- a/frontend/src/pages/PrivacyPage/PrivacyPage.tsx
+++ b/frontend/src/pages/PrivacyPage/PrivacyPage.tsx
@@ -1,0 +1,84 @@
+import { Typography } from '../../components/ui/Typography/Typography'
+import { Divider } from '../../components/ui/Divider/Divider'
+import styles from './PrivacyPage.module.css'
+
+/**
+ * プライバシーポリシーページ (/privacy)
+ *
+ * Cookie 同意バナーを実装しない方針のため、計測内容・PII の取り扱い・
+ * オプトアウト方法をこのページに明記する。日本 APPI 対応の一環。
+ *
+ * Spec: docs/superpowers/specs/2026-04-13-analytics-tracking-design.md 4 節
+ * ADR: docs/adr/0041-プロダクト分析ツールにposthogを採用.md
+ */
+export function PrivacyPage() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.content}>
+        <Typography variant="h1">プライバシーポリシー</Typography>
+        <Divider />
+
+        <section className={styles.section}>
+          <Typography variant="h2">1. 取得する情報</Typography>
+          <Typography variant="body">
+            Recolly（以下「本サービス」）では、サービス改善と利用状況の把握のため、
+            以下の情報を自動的に取得します。
+          </Typography>
+          <ul className={styles.list}>
+            <li>ページの閲覧履歴（どの画面を開いたか）</li>
+            <li>操作イベント（新規登録、記録作成など）</li>
+            <li>ログイン状態（ログイン中のユーザー内部 ID）</li>
+            <li>アクセスしたブラウザ・デバイス情報</li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">2. 利用する解析ツール</Typography>
+          <Typography variant="body">
+            本サービスは解析ツールとして <strong>PostHog</strong> を利用しています。 PostHog
+            は世界中で利用されているプロダクト分析ツールで、
+            本サービスの改善のためにイベントデータを収集します。
+          </Typography>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">3. 送信しない情報（匿名性の担保）</Typography>
+          <Typography variant="body">以下の情報は PostHog に送信しません:</Typography>
+          <ul className={styles.list}>
+            <li>メールアドレス</li>
+            <li>パスワード</li>
+            <li>作品の感想本文</li>
+            <li>掲示板のコメント本文</li>
+            <li>プロフィールの自己紹介文</li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">4. オプトアウト（計測拒否）の方法</Typography>
+          <Typography variant="body">
+            計測を拒否したい場合は、ブラウザのプライバシー設定で Cookie / localStorage を
+            拒否することで PostHog のトラッキングを無効化できます。
+            本サービスは計測を無効化していても基本機能をご利用いただけます。
+          </Typography>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">5. 利用目的</Typography>
+          <ul className={styles.list}>
+            <li>サービスの利用状況を把握し、機能改善に活用するため</li>
+            <li>ユーザーの継続率・離脱ポイントを分析し、体験を改善するため</li>
+            <li>不具合の発見と修正のため</li>
+          </ul>
+        </section>
+
+        <section className={styles.section}>
+          <Typography variant="h2">6. お問い合わせ</Typography>
+          <Typography variant="body">
+            本ポリシーに関するお問い合わせは、本サービスの GitHub リポジトリ経由で
+            受け付けています。
+          </Typography>
+        </section>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/pages/RecommendationsPage/RecommendationsPage.test.tsx
+++ b/frontend/src/pages/RecommendationsPage/RecommendationsPage.test.tsx
@@ -4,11 +4,20 @@ import { MemoryRouter } from 'react-router-dom'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { RecommendationsPage } from './RecommendationsPage'
 import { recommendationsApi } from '../../lib/recommendationsApi'
+import { recordsApi } from '../../lib/recordsApi'
 
 vi.mock('../../lib/recommendationsApi')
+vi.mock('../../lib/recordsApi')
 vi.mock('../../contexts/useAuth', () => ({
   useAuth: () => ({ user: { id: 1, username: 'testuser' } }),
 }))
+
+// PostHog ラッパーをモック化
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+}))
+
+import { captureEvent } from '../../lib/analytics/posthog'
 
 const mockReadyResponse = {
   recommendation: {
@@ -168,5 +177,68 @@ describe('RecommendationsPage', () => {
 
     await user.click(screen.getByText('分析を更新'))
     expect(recommendationsApi.refresh).toHaveBeenCalled()
+  })
+
+  it('レコメンドから記録を作成したら record_created を media_type 付きで発火する', async () => {
+    vi.mocked(recommendationsApi.get).mockResolvedValue(mockReadyResponse)
+    vi.mocked(recordsApi.createFromSearchResult).mockResolvedValue({
+      record: {
+        id: 99,
+        work_id: 1,
+        status: 'watching',
+        rating: null,
+        current_episode: 0,
+        rewatch_count: 0,
+        review_text: null,
+        visibility: 'private_record',
+        started_at: null,
+        completed_at: null,
+        created_at: '2026-04-13T00:00:00Z',
+        updated_at: '2026-04-13T00:00:00Z',
+        work: {
+          id: 1,
+          title: '葬送のフリーレン',
+          media_type: 'anime',
+          description: null,
+          cover_image_url: null,
+          total_episodes: null,
+          external_api_id: '154587',
+          external_api_source: 'anilist',
+          metadata: {},
+          created_at: '2026-04-13T00:00:00Z',
+          updated_at: '2026-04-13T00:00:00Z',
+        },
+        tags: [],
+      },
+    })
+
+    const user = userEvent.setup()
+
+    render(
+      <MemoryRouter>
+        <RecommendationsPage />
+      </MemoryRouter>,
+    )
+
+    // mockReadyResponse の葬送のフリーレン (media_type: anime) のカードが表示される
+    await waitFor(() => {
+      expect(screen.getByText('葬送のフリーレン')).toBeInTheDocument()
+    })
+
+    // 記録モーダルを開く
+    const recordButtons = screen.getAllByRole('button', { name: '記録する' })
+    await user.click(recordButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('葬送のフリーレンを記録')).toBeInTheDocument()
+    })
+
+    // モーダル内の確定ボタンをクリック
+    const confirmButtons = screen.getAllByRole('button', { name: '記録する' })
+    await user.click(confirmButtons[confirmButtons.length - 1])
+
+    await waitFor(() => {
+      expect(captureEvent).toHaveBeenCalledWith('record_created', { media_type: 'anime' })
+    })
   })
 })

--- a/frontend/src/pages/RecommendationsPage/RecommendationsPage.tsx
+++ b/frontend/src/pages/RecommendationsPage/RecommendationsPage.tsx
@@ -8,6 +8,8 @@ import { useRecommendations } from '../../hooks/useRecommendations'
 import { recordsApi } from '../../lib/recordsApi'
 import { getGenreLabel, getMediaTypeLabel } from '../../lib/mediaTypeUtils'
 import { useRecollyMotion } from '../../lib/motion'
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
 import type { MediaType, RecordStatus } from '../../lib/types'
 import type { RecommendedWork } from '../../types/recommendation'
 import { AnalysisSummaryCard } from './AnalysisSummaryCard'
@@ -49,6 +51,10 @@ export function RecommendationsPage() {
         },
         recordData,
       )
+      // ジャンル横断率計測の基点イベント
+      captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
+        media_type: modalWork.media_type as MediaType,
+      })
       setRecordedIds((prev) => new Set(prev).add(workKey))
       setModalWork(null)
     } catch {

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -13,7 +13,20 @@ beforeEach(() => {
   // 初回セッション確認: 認証済み
   mockFetch.mockResolvedValueOnce({
     ok: true,
-    json: () => Promise.resolve({ user: { id: 1, username: 'test', email: 'test@example.com' } }),
+    json: () =>
+      Promise.resolve({
+        user: {
+          id: 1,
+          username: 'test',
+          email: 'test@example.com',
+          avatar_url: null,
+          bio: null,
+          created_at: '2026-04-01T00:00:00Z',
+          has_password: true,
+          providers: [],
+          email_missing: false,
+        },
+      }),
   })
   // SearchPage マウント時の recorded_external_ids 取得
   mockFetch.mockResolvedValueOnce({

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -5,11 +5,21 @@ import { BrowserRouter } from 'react-router-dom'
 import { AuthProvider } from '../../contexts/AuthContext'
 import { SearchPage } from './SearchPage'
 
+// PostHog ラッパーをモック化
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+  identifyUser: vi.fn(),
+  resetAnalytics: vi.fn(),
+}))
+
+import { captureEvent } from '../../lib/analytics/posthog'
+
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
 beforeEach(() => {
   mockFetch.mockReset()
+  vi.mocked(captureEvent).mockClear()
   // 初回セッション確認: 認証済み
   mockFetch.mockResolvedValueOnce({
     ok: true,
@@ -459,5 +469,64 @@ describe('SearchPage', () => {
     await new Promise((resolve) => setTimeout(resolve, 50))
     expect(screen.queryByText('遅延した古い結果')).not.toBeInTheDocument()
     expect(screen.getByText('ワンピース新結果')).toBeInTheDocument()
+  })
+
+  it('検索結果から記録を作成したら record_created を media_type 付きで発火する', async () => {
+    renderSearchPage()
+    const user = userEvent.setup()
+
+    // 検索API: アニメ作品 1 件を返す
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              title: 'テストアニメ',
+              media_type: 'anime',
+              description: 'アニメ説明',
+              cover_image_url: null,
+              total_episodes: 12,
+              external_api_id: '1',
+              external_api_source: 'anilist',
+              metadata: {},
+            },
+          ],
+        }),
+    })
+
+    // 検索実行
+    const searchInput = await screen.findByPlaceholderText('作品を検索...')
+    await user.type(searchInput, 'テスト')
+    await user.click(screen.getByRole('button', { name: '検索' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメ')).toBeInTheDocument()
+    })
+
+    // 記録モーダルを開く
+    const recordButtons = screen.getAllByRole('button', { name: '記録する' })
+    await user.click(recordButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメを記録')).toBeInTheDocument()
+    })
+
+    // 記録 API: 成功を返す
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          record: { id: 1, status: 'watching', rating: null },
+        }),
+    })
+
+    // モーダル内の「記録する」をクリック
+    const confirmButtons = screen.getAllByRole('button', { name: '記録する' })
+    await user.click(confirmButtons[confirmButtons.length - 1])
+
+    await waitFor(() => {
+      expect(captureEvent).toHaveBeenCalledWith('record_created', { media_type: 'anime' })
+    })
   })
 })

--- a/frontend/src/pages/SearchPage/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.tsx
@@ -17,6 +17,8 @@ import { RecordModal } from '../../components/RecordModal/RecordModal'
 import { SectionTitle } from '../../components/ui/SectionTitle/SectionTitle'
 import { Button } from '../../components/ui/Button/Button'
 import { getGenreLabel } from '../../lib/mediaTypeUtils'
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
 import { GenreDropdown } from './GenreDropdown'
 import { GENRE_FILTERS } from './genreFilters'
 import type { GenreFilter } from './genreFilters'
@@ -118,12 +120,19 @@ export function SearchPage() {
         // 手動登録作品: work_idで直接Record作成
         setLoadingId('manual')
         await recordsApi.createFromWorkId(manualWorkId, data)
+        // ジャンル横断率・ファネル分析の基点となるイベント発火
+        captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
+          media_type: modalWork.media_type,
+        })
         setManualWorkId(null)
       } else {
         // 検索結果作品: 既存のフロー
         const workKey = `${modalWork.external_api_source}:${modalWork.external_api_id}`
         setLoadingId(workKey)
         await recordsApi.createFromSearchResult(modalWork, data)
+        captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
+          media_type: modalWork.media_type,
+        })
         setRecordedIds((prev) => new Set(prev).add(workKey))
       }
       setModalWork(null)

--- a/frontend/src/pages/SignUpPage/SignUpPage.test.tsx
+++ b/frontend/src/pages/SignUpPage/SignUpPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { BrowserRouter } from 'react-router-dom'
 import { AuthProvider } from '../../contexts/AuthContext'
@@ -10,11 +10,21 @@ vi.mock('../../components/OAuthButtons/OAuthButtons', () => ({
   OAuthButtons: () => <div data-testid="oauth-buttons-mock">Googleログイン（mock）</div>,
 }))
 
+// PostHog ラッパーをモック化
+vi.mock('../../lib/analytics/posthog', () => ({
+  captureEvent: vi.fn(),
+  identifyUser: vi.fn(),
+  resetAnalytics: vi.fn(),
+}))
+
+import { captureEvent } from '../../lib/analytics/posthog'
+
 const mockFetch = vi.fn()
 vi.stubGlobal('fetch', mockFetch)
 
 beforeEach(() => {
   mockFetch.mockReset()
+  vi.mocked(captureEvent).mockClear()
   // 初回セッション確認: 未認証
   mockFetch.mockResolvedValueOnce({
     ok: false,
@@ -51,7 +61,19 @@ describe('SignUpPage', () => {
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: () =>
-        Promise.resolve({ user: { id: 1, username: 'newuser', email: 'new@example.com' } }),
+        Promise.resolve({
+          user: {
+            id: 1,
+            username: 'newuser',
+            email: 'new@example.com',
+            avatar_url: null,
+            bio: null,
+            created_at: '2026-04-13T00:00:00Z',
+            has_password: true,
+            providers: [],
+            email_missing: false,
+          },
+        }),
     })
 
     await user.type(await screen.findByLabelText('ユーザー名'), 'newuser')
@@ -94,5 +116,39 @@ describe('SignUpPage', () => {
   it('OAuthボタンが表示される', async () => {
     renderSignUpPage()
     expect(await screen.findByTestId('oauth-buttons-mock')).toBeInTheDocument()
+  })
+
+  it('登録成功時に signup_completed イベントを method=email で発火する', async () => {
+    renderSignUpPage()
+    const user = userEvent.setup()
+
+    // 登録API成功
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          user: {
+            id: 1,
+            username: 'newuser',
+            email: 'new@example.com',
+            avatar_url: null,
+            bio: null,
+            created_at: '2026-04-13T00:00:00Z',
+            has_password: true,
+            providers: [],
+            email_missing: false,
+          },
+        }),
+    })
+
+    await user.type(await screen.findByLabelText('ユーザー名'), 'newuser')
+    await user.type(screen.getByLabelText('メールアドレス'), 'new@example.com')
+    await user.type(screen.getByLabelText('パスワード'), 'password123')
+    await user.type(screen.getByLabelText('パスワード（確認）'), 'password123')
+    await user.click(screen.getByRole('button', { name: 'アカウントを作成' }))
+
+    await waitFor(() => {
+      expect(captureEvent).toHaveBeenCalledWith('signup_completed', { method: 'email' })
+    })
   })
 })

--- a/frontend/src/pages/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage/SignUpPage.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { OAuthButtons } from '../../components/OAuthButtons/OAuthButtons'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { Footer } from '../../components/ui/Footer/Footer'
 import { captureEvent } from '../../lib/analytics/posthog'
 import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
 import styles from '../../styles/authForm.module.css'
@@ -51,59 +52,62 @@ export function SignUpPage() {
   }
 
   return (
-    <div className={styles.page}>
-      <div className={styles.card}>
-        <Typography variant="h2">アカウント作成</Typography>
-        <Divider />
-        <form className={styles.form} onSubmit={handleSubmit}>
-          <FormInput
-            label="ユーザー名"
-            id="username"
-            type="text"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            required
-            autoComplete="username"
-          />
-          <FormInput
-            label="メールアドレス"
-            id="email"
-            type="email"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-            autoComplete="email"
-          />
-          <FormInput
-            label="パスワード"
-            id="password"
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-            minLength={6}
-            autoComplete="new-password"
-          />
-          <FormInput
-            label="パスワード（確認）"
-            id="passwordConfirmation"
-            type="password"
-            value={passwordConfirmation}
-            onChange={(e) => setPasswordConfirmation(e.target.value)}
-            required
-            minLength={6}
-            autoComplete="new-password"
-          />
-          {error && <p className={styles.error}>{error}</p>}
-          <Button variant="primary" type="submit" disabled={isSubmitting}>
-            {isSubmitting ? '登録中...' : 'アカウントを作成'}
-          </Button>
-        </form>
-        <OAuthButtons />
-        <div className={styles.link}>
-          <Link to="/login">ログインはこちら</Link>
+    <div className={styles.layout}>
+      <div className={styles.page}>
+        <div className={styles.card}>
+          <Typography variant="h2">アカウント作成</Typography>
+          <Divider />
+          <form className={styles.form} onSubmit={handleSubmit}>
+            <FormInput
+              label="ユーザー名"
+              id="username"
+              type="text"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              required
+              autoComplete="username"
+            />
+            <FormInput
+              label="メールアドレス"
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+            />
+            <FormInput
+              label="パスワード"
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={6}
+              autoComplete="new-password"
+            />
+            <FormInput
+              label="パスワード（確認）"
+              id="passwordConfirmation"
+              type="password"
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              required
+              minLength={6}
+              autoComplete="new-password"
+            />
+            {error && <p className={styles.error}>{error}</p>}
+            <Button variant="primary" type="submit" disabled={isSubmitting}>
+              {isSubmitting ? '登録中...' : 'アカウントを作成'}
+            </Button>
+          </form>
+          <OAuthButtons />
+          <div className={styles.link}>
+            <Link to="/login">ログインはこちら</Link>
+          </div>
         </div>
       </div>
+      <Footer />
     </div>
   )
 }

--- a/frontend/src/pages/SignUpPage/SignUpPage.tsx
+++ b/frontend/src/pages/SignUpPage/SignUpPage.tsx
@@ -8,6 +8,8 @@ import { Button } from '../../components/ui/Button/Button'
 import { Divider } from '../../components/ui/Divider/Divider'
 import { OAuthButtons } from '../../components/OAuthButtons/OAuthButtons'
 import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { captureEvent } from '../../lib/analytics/posthog'
+import { ANALYTICS_EVENTS } from '../../lib/analytics/events'
 import styles from '../../styles/authForm.module.css'
 
 export function SignUpPage() {
@@ -33,6 +35,9 @@ export function SignUpPage() {
 
     try {
       await signup(username, email, password, passwordConfirmation)
+      // 登録完了イベント発火（method: email）
+      // ジャンル横断率や signup → 記録ファネル分析の基点になる
+      captureEvent(ANALYTICS_EVENTS.SIGNUP_COMPLETED, { method: 'email' })
       navigate('/dashboard')
     } catch (err) {
       if (err instanceof ApiError) {

--- a/frontend/src/styles/authForm.module.css
+++ b/frontend/src/styles/authForm.module.css
@@ -1,9 +1,17 @@
+/* ページ全体のレイアウトラッパー: フォーム中央寄せ + 下部 Footer 配置 */
+.layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100dvh;
+  background-color: var(--color-bg);
+}
+
 .page {
+  flex: 1 1 auto;
   display: flex;
   justify-content: center;
   align-items: center;
-  min-height: 100vh;
-  background-color: var(--color-bg);
+  padding: var(--spacing-xl) 0;
 }
 
 .card {


### PR DESCRIPTION
Closes #143

## Summary

PostHog を導入して Phase 1 の 4 イベント（\$pageview / \$identify / signup_completed / record_created）を計測できる状態にしました。差別化指標「ジャンル横断率」の計測基盤が整います。

- **ラッパー設計**: \`frontend/src/lib/analytics/\` に薄いラッパーを置き、環境変数未設定時は no-op、init/capture 失敗時は例外を握りつぶして本体動作を止めない
- **pageview**: SDK 自動発火を無効化し、\`PageviewTracker\` で React Router の location 変化を監視して手動発火（初回ロードも含めて統一）
- **identify/reset**: \`AuthProvider\` の useEffect で user state 変化を監視。login / signup / OAuth / initial session 復帰 / logout の全パスで確実に 1 回発火
- **signup_completed**: email 登録 (SignUpPage) と Google OAuth 登録 (OauthUsernamePage) の両方で method プロパティ付きで発火
- **record_created**: SearchPage / RecommendationsPage の両方で media_type プロパティ付き発火（ジャンル横断率計測の基点）
- **プライバシー対応**: \`/privacy\` ページと共通 Footer を新設。Cookie 同意バナー非採用の代替としてプライバシーポリシーへの導線を常に露出

### 実装したファイル

**新規:**
- \`frontend/src/lib/analytics/{events.ts,posthog.ts,posthog.test.ts}\`
- \`frontend/src/components/PageviewTracker/\`
- \`frontend/src/components/ui/Footer/\`
- \`frontend/src/pages/PrivacyPage/\`
- \`docs/superpowers/plans/2026-04-13-analytics-tracking.md\`

**修正:**
- \`frontend/package.json\` — posthog-js@^1.367.0 追加
- \`frontend/src/main.tsx\` — PostHog 初期化
- \`frontend/src/App.tsx\` / \`App.module.css\` — PageviewTracker / /privacy ルート / Footer 組み込み
- \`frontend/src/contexts/AuthContext.tsx\` — identify/reset の自動発火
- \`frontend/src/pages/{SignUpPage,OauthUsernamePage,SearchPage,RecommendationsPage}/\` — 各イベント発火
- \`frontend/src/pages/{LoginPage,SignUpPage,PasswordNewPage,PasswordEditPage,OauthUsernamePage,EmailPromptPage}/\` — Footer 追加
- \`frontend/src/styles/authForm.module.css\` — .layout ラッパー追加
- 既存テストの user mock を User 型に合わせて修正（AuthContext.test / ProtectedRoute.test / LoginPage.test / SearchPage.test）

## Spec Coverage

Spec `docs/superpowers/specs/2026-04-13-analytics-tracking-design.md` の全要件に対応:

- [x] posthog-js 依存追加 (§3.1)
- [x] 環境変数未設定時の no-op (§3.4)
- [x] \$pageview SPA 手動発火 (§3.7)
- [x] \$identify ログイン時・reset ログアウト時 (§3.5)
- [x] signup_completed (email / google) (§3.5)
- [x] record_created + media_type (§3.5)
- [x] /privacy ページ (§4.4)
- [x] フッター導線 (§4.4)
- [x] PII (email 本文・パスワード・感想本文・コメント本文・bio) 非送信
- [x] ユニットテスト (§5.1)
- [x] 統合テスト (§5.2)

## Test Plan

- [x] \`frontend && npm run test\`: 73 ファイル / 496 テスト 全 PASS
- [x] \`frontend && npm run typecheck\`: エラーなし
- [x] \`frontend && npm run lint\`: エラーなし
- [x] \`frontend && npm run build\`: 成功（PrivacyPage が 3.33 kB / gzip 1.31 kB の lazy chunk として分離）
- [x] Playwright MCP 自動確認:
  - ログインページで Footer + プライバシーポリシーリンク表示
  - \`POST https://us.i.posthog.com/e/\` = 200 (初回 pageview)
  - \`/privacy\` 遷移後に \`POST https://us.i.posthog.com/i/v0/e/\` = 200 (SPA 遷移 pageview)
  - PrivacyPage の 6 セクション全てレンダリング
- [ ] **マージ後に手動確認**: PostHog Live events ページで以下が届くか確認
  - ログイン / ログアウトで \$identify / \$reset
  - 新規登録 (email / OAuth) で signup_completed
  - 記録作成で record_created + media_type

## Out of Scope (本 PR では扱わない)

- Phase 2 以降のイベント（search_performed, episode_progress_updated 等）
- A/B テスト機能・セッション録画
- バックエンド側イベント発火
- EU GDPR の Cookie consent banner
- PostHog Dashboard / Insight 作成（実装後に別タスク）

## 関連文書

- Spec: \`docs/superpowers/specs/2026-04-13-analytics-tracking-design.md\`
- ADR: \`docs/adr/0041-プロダクト分析ツールにposthogを採用.md\`
- Plan: \`docs/superpowers/plans/2026-04-13-analytics-tracking.md\`