### PR TITLE
feat(frontend): 作品詳細の感想タブを表示/編集モード化して全文を展開表示する

### DIFF
--- a/docs/superpowers/plans/2026-04-14-work-review-display.md
+++ b/docs/superpowers/plans/2026-04-14-work-review-display.md
@@ -1,0 +1,933 @@
+# 作品詳細 感想タブ 表示/編集モード化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 作品詳細ページの `ReviewSection` を empty / view / edit の 3 モードに分離し、感想の全文展開表示とインライン編集切り替えを実現する。
+
+**Architecture:** `ReviewSection.tsx` 内で `mode` ステートを分岐。外部 Props（`reviewText`, `onSave`）は不変。保存エラー伝播のため `useWorkDetail.handleReviewTextSave` のみ微修正（`updateRecord` のエラー握りつぶしを経由しないように直接 `recordsApi.update` を呼ぶ）。データモデル・バックエンド非変更。
+
+**Tech Stack:** React 19 / TypeScript / Vitest + React Testing Library / CSS Modules（`tokens.css` 準拠）
+
+**Spec:** `docs/superpowers/specs/2026-04-14-work-review-display-design.md`
+**Issue:** IKcoding-jp/Recolly#146
+
+---
+
+## 設計判断サマリ
+
+| 判断事項 | 決定 | 理由 |
+|---|---|---|
+| 単一感想 vs 複数感想 | 単一感想（現状維持） | スペックで確定。データモデル非変更 |
+| 編集モード切替方式 | インライン切替 | モーダル/別ページは過剰。既存実装に近い |
+| 書式対応 | プレーンテキスト + 改行保持（`white-space: pre-wrap`） | YAGNI。Markdown は別スコープ |
+| 空状態 | 「感想を書く」ボタン付きメッセージ | Recolly 既存 EmptyState パターン（`WorkDetailPage.module.css` の `.empty` 等）と揃える |
+| エラー表示方法 | インラインで赤字メッセージ 1 行（`ActionErrorCard` は使わない） | 編集中のインライン表示として `ActionErrorCard` はタイトル付きで重い |
+| **`useWorkDetail` の修正** | **`handleReviewTextSave` のみ、`updateRecord` を経由せず `recordsApi.update` を直接呼ぶ形に変更** | `updateRecord` は try/catch でエラーを握りつぶす設計なので、現状のままでは `ReviewSection` 側のエラー処理が発火しない。他の handler（status/rating 等）への影響を避けるため、`handleReviewTextSave` のみ局所的に修正 |
+| `WorkDetailPage.tsx` の変更 | なし | Props 不変のため |
+| キャンセル確認 | なし（無言で破棄） | 他の編集 UI と一貫性 |
+
+---
+
+## File Structure
+
+**修正:**
+
+- `frontend/src/components/ReviewSection/ReviewSection.tsx` — 3モード分岐に書き換え
+- `frontend/src/components/ReviewSection/ReviewSection.module.css` — 空状態・表示モード・エラー表示のスタイル追加
+- `frontend/src/components/ReviewSection/ReviewSection.test.tsx` — 全面書き換え（既存 5 テスト → 新 19 テスト）
+- `frontend/src/pages/WorkDetailPage/useWorkDetail.ts` — `handleReviewTextSave` を直接 `recordsApi.update` 呼び出しに変更
+
+**新規作成:**
+
+なし
+
+**変更しないファイル（重要）:**
+
+- `frontend/src/pages/WorkDetailPage/WorkDetailPage.tsx`
+- バックエンド全般
+
+---
+
+## Task 1: `useWorkDetail.handleReviewTextSave` でエラーを伝播させる
+
+**Files:**
+- Modify: `frontend/src/pages/WorkDetailPage/useWorkDetail.ts`
+
+このタスクは ReviewSection のエラーハンドリングが機能するための前提。`updateRecord` の共通化を外して、`handleReviewTextSave` では `recordsApi.update` を直接呼び、エラーを呼び出し元に throw させる。
+
+- [ ] **Step 1: `useWorkDetail.ts` の `handleReviewTextSave` を直接呼び出しに変更**
+
+修正箇所: `frontend/src/pages/WorkDetailPage/useWorkDetail.ts:118-123`
+
+変更前:
+
+```typescript
+const handleReviewTextSave = useCallback(
+  async (text: string) => {
+    await updateRecord({ review_text: text })
+  },
+  [updateRecord],
+)
+```
+
+変更後:
+
+```typescript
+const handleReviewTextSave = useCallback(
+  async (text: string) => {
+    if (!state.record) return
+    // 注意: updateRecord を経由するとエラーが握りつぶされるので、
+    // ReviewSection 側でエラー表示できるように直接呼び出して例外を伝播させる
+    const res = await recordsApi.update(state.record.id, { review_text: text })
+    setState((prev) => ({ ...prev, record: res.record }))
+  },
+  [state.record],
+)
+```
+
+- [ ] **Step 2: TypeScript チェックが通ることを確認**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: エラーなし
+
+- [ ] **Step 3: 既存の `WorkDetailPage.test.tsx` を実行して回帰がないことを確認**
+
+Run: `cd frontend && npx vitest run src/pages/WorkDetailPage/WorkDetailPage.test.tsx`
+Expected: 全パス
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add frontend/src/pages/WorkDetailPage/useWorkDetail.ts
+git commit -m "fix(frontend): 感想保存エラーを ReviewSection に伝播させる"
+```
+
+---
+
+## Task 2: `ReviewSection` を empty モード対応に書き換え（既存テスト全削除）
+
+**Files:**
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.tsx`
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.module.css`
+
+ここで 3 モードの骨組みを入れ、empty モードを実装する。既存テストは全て新設計に合わないため削除し、新テストを追加する方式。
+
+- [ ] **Step 1: テストファイルを全面書き換え（empty モードの 5 テスト）**
+
+`frontend/src/components/ReviewSection/ReviewSection.test.tsx` の内容を以下で置き換える:
+
+```typescript
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { ReviewSection } from './ReviewSection'
+
+describe('ReviewSection', () => {
+  let mockOnSave: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockOnSave = vi.fn().mockResolvedValue(undefined)
+  })
+
+  describe('empty モード', () => {
+    it('reviewText が null の時、空状態メッセージが表示される', () => {
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
+    })
+
+    it('reviewText が空文字の時、空状態メッセージが表示される', () => {
+      render(<ReviewSection reviewText="" onSave={mockOnSave} />)
+      expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
+    })
+
+    it('「感想を書く」ボタンが表示される', () => {
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      expect(screen.getByRole('button', { name: '感想を書く' })).toBeInTheDocument()
+    })
+
+    it('「感想を書く」クリックで編集モードに切り替わる', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      expect(screen.getByPlaceholderText('作品の感想を書く...')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
+    })
+
+    it('空状態では「編集」「保存」ボタンが表示されない', () => {
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      expect(screen.queryByRole('button', { name: '編集' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument()
+    })
+  })
+})
+```
+
+- [ ] **Step 2: テスト実行して全 5 テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: FAIL（「まだ感想が書かれていません」要素が見つからない、等）
+
+- [ ] **Step 3: `ReviewSection.tsx` を empty モード + 基本骨組みで書き換え**
+
+`frontend/src/components/ReviewSection/ReviewSection.tsx` を以下で置き換える:
+
+```typescript
+import { useState, useEffect, useCallback } from 'react'
+import { Button } from '../ui/Button/Button'
+import { FormTextarea } from '../ui/FormTextarea/FormTextarea'
+import styles from './ReviewSection.module.css'
+
+type ReviewSectionProps = {
+  reviewText: string | null
+  onSave: (text: string) => Promise<void> | void
+}
+
+type Mode = 'empty' | 'view' | 'edit'
+
+const EDIT_ROWS = 8
+const SAVE_ERROR_MESSAGE = '保存に失敗しました。もう一度お試しください。'
+
+const computeInitialMode = (reviewText: string | null): Mode =>
+  reviewText ? 'view' : 'empty'
+
+export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
+  const [mode, setMode] = useState<Mode>(() => computeInitialMode(reviewText))
+  const [draft, setDraft] = useState<string>(reviewText ?? '')
+  const [isSaving, setIsSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // 親から reviewText が変わった時、編集中でなければ追従する
+  useEffect(() => {
+    if (mode !== 'edit') {
+      setMode(computeInitialMode(reviewText))
+      setDraft(reviewText ?? '')
+    }
+    // mode を依存配列に含めない: 編集中に mode が変わるたびに再同期するのを避けるため
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reviewText])
+
+  const handleStartEdit = useCallback(() => {
+    setDraft(reviewText ?? '')
+    setSaveError(null)
+    setMode('edit')
+  }, [reviewText])
+
+  const handleCancel = useCallback(() => {
+    setDraft(reviewText ?? '')
+    setSaveError(null)
+    setMode(computeInitialMode(reviewText))
+  }, [reviewText])
+
+  const handleSave = useCallback(async () => {
+    setIsSaving(true)
+    setSaveError(null)
+    try {
+      await onSave(draft)
+      // 保存成功: edit モードを抜けて、draft の内容に応じて view / empty に遷移
+      // useEffect は mode === 'edit' の時は同期をスキップするため、ここで明示的に遷移する
+      // 親の reviewText 更新と一緒にバッチされるので、中間状態は描画されない
+      setMode(draft ? 'view' : 'empty')
+    } catch {
+      setSaveError(SAVE_ERROR_MESSAGE)
+    } finally {
+      setIsSaving(false)
+    }
+  }, [draft, onSave])
+
+  if (mode === 'empty') {
+    return (
+      <div className={styles.empty}>
+        <p className={styles.emptyMessage}>まだ感想が書かれていません</p>
+        <Button variant="primary" size="sm" onClick={handleStartEdit}>
+          感想を書く
+        </Button>
+      </div>
+    )
+  }
+
+  // 現時点では view/edit は後続 Task で実装する暫定的な表示
+  if (mode === 'edit') {
+    return (
+      <div className={styles.container}>
+        <FormTextarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="作品の感想を書く..."
+          rows={EDIT_ROWS}
+        />
+        <div className={styles.actions}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleCancel}
+            disabled={isSaving}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={isSaving}
+            onClick={() => void handleSave()}
+          >
+            {isSaving ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  // view モード（Task 3 で本実装）
+  return null
+}
+```
+
+- [ ] **Step 4: CSS に空状態と `actions` の gap 追加**
+
+`frontend/src/components/ReviewSection/ReviewSection.module.css` を以下で置き換える:
+
+```css
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+/* FormTextareaのボトムラインをアウトラインに上書き */
+.container textarea {
+  border: var(--border-width) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-sm);
+  padding: var(--spacing-md);
+  min-height: 160px;
+  background: var(--color-bg-white);
+}
+
+.container textarea:focus {
+  border-color: var(--color-text);
+  border-bottom-color: var(--color-text);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+/* empty モード */
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xl);
+  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-white);
+}
+
+.emptyMessage {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+}
+```
+
+- [ ] **Step 5: テスト実行、empty モードの 5 テストが全パスすることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: PASS 5, FAIL 0
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/components/ReviewSection/
+git commit -m "feat(frontend): ReviewSection の empty モードを実装"
+```
+
+---
+
+## Task 3: view モード実装（表示・編集遷移）
+
+**Files:**
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.tsx`
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.module.css`
+
+- [ ] **Step 1: view モードのテストを追加**
+
+`ReviewSection.test.tsx` の `describe('empty モード', ...)` の後に、以下の `describe` ブロックを追加:
+
+```typescript
+  describe('view モード', () => {
+    it('reviewText に値がある時、本文が表示される', () => {
+      render(<ReviewSection reviewText="素晴らしい作品" onSave={mockOnSave} />)
+      expect(screen.getByText('素晴らしい作品')).toBeInTheDocument()
+    })
+
+    it('改行を含むテキストで pre-wrap スタイルが適用される', () => {
+      const text = '1行目\n2行目\n3行目'
+      const { container } = render(
+        <ReviewSection reviewText={text} onSave={mockOnSave} />,
+      )
+      const textEl = container.querySelector('p')
+      expect(textEl?.textContent).toBe(text)
+      expect(textEl?.className).toMatch(/viewText/)
+    })
+
+    it('「編集」ボタンが表示される', () => {
+      render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument()
+    })
+
+    it('「編集」クリックで編集モードに切り替わり、既存テキストが入っている', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      expect(screen.getByDisplayValue('感想')).toBeInTheDocument()
+    })
+
+    it('view モードではテキストエリアが表示されない', () => {
+      render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      expect(screen.queryByPlaceholderText('作品の感想を書く...')).not.toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: テスト実行して新規 5 テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: empty モードの 5 テストはパス、view モードの 5 テストが失敗（「素晴らしい作品」要素がない、等）
+
+- [ ] **Step 3: `ReviewSection.tsx` の view モードの `return null` を実装に置き換え**
+
+`ReviewSection.tsx` の末尾 `return null` を以下に置き換える:
+
+```typescript
+  // view モード
+  return (
+    <div className={styles.viewContainer}>
+      <div className={styles.viewActions}>
+        <Button variant="secondary" size="sm" onClick={handleStartEdit}>
+          編集
+        </Button>
+      </div>
+      <p className={styles.viewText}>{reviewText}</p>
+    </div>
+  )
+```
+
+- [ ] **Step 4: CSS に view モード用スタイルを追加**
+
+`ReviewSection.module.css` の末尾に以下を追加:
+
+```css
+/* view モード */
+.viewContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.viewActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.viewText {
+  margin: 0;
+  padding: var(--spacing-md);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-relaxed);
+  white-space: pre-wrap;
+  background: var(--color-bg-white);
+  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-sm);
+}
+```
+
+- [ ] **Step 5: テスト実行、view モード 5 テスト + empty モード 5 テストで計 10 テストがパスすることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: PASS 10, FAIL 0
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/components/ReviewSection/
+git commit -m "feat(frontend): ReviewSection の view モードを実装"
+```
+
+---
+
+## Task 4: edit モード保存テスト追加と挙動検証
+
+**Files:**
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`
+
+Task 2 で edit モードの UI は既に実装済みだが、保存挙動のテストがない。このタスクでテストを追加する。
+
+- [ ] **Step 1: edit モード保存系テストを追加**
+
+`ReviewSection.test.tsx` の末尾 `describe('view モード', ...)` の後に追加:
+
+```typescript
+  describe('edit モード - 保存', () => {
+    it('保存ボタンをクリックすると onSave が新しいテキストで呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.type(textarea, '新しい感想')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('新しい感想')
+      })
+    })
+
+    it('保存中は保存ボタンが「保存中...」表示で disabled になる', async () => {
+      const user = userEvent.setup()
+      let resolveSave: (() => void) | undefined
+      mockOnSave.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          }),
+      )
+      render(<ReviewSection reviewText="text" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      const savingBtn = await screen.findByRole('button', { name: '保存中...' })
+      expect(savingBtn).toBeDisabled()
+      resolveSave?.()
+    })
+
+    it('保存成功後、親が reviewText を更新すると view モードに戻る', async () => {
+      const user = userEvent.setup()
+      const { rerender } = render(
+        <ReviewSection reviewText="" onSave={mockOnSave} />,
+      )
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.type(textarea, '保存後')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalled())
+      // 親が reviewText を更新したことをシミュレート
+      rerender(<ReviewSection reviewText="保存後" onSave={mockOnSave} />)
+      expect(screen.getByText('保存後')).toBeInTheDocument()
+      expect(
+        screen.queryByPlaceholderText('作品の感想を書く...'),
+      ).not.toBeInTheDocument()
+    })
+  })
+```
+
+`waitFor` を使うので、既存のインポートに `waitFor` を追加:
+
+```typescript
+import { render, screen, waitFor } from '@testing-library/react'
+```
+
+- [ ] **Step 2: テスト実行、全 13 テストがパスすることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: PASS 13, FAIL 0
+
+すべて Task 2 で実装済みのコードが既にこの挙動を満たしている前提。もし失敗したら、該当の実装にバグがあるのでデバッグする。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/components/ReviewSection/ReviewSection.test.tsx
+git commit -m "test(frontend): ReviewSection の edit モード保存テストを追加"
+```
+
+---
+
+## Task 5: edit モード キャンセルテスト追加
+
+**Files:**
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`
+
+- [ ] **Step 1: キャンセル系テストを追加**
+
+`ReviewSection.test.tsx` の末尾 `describe('edit モード - 保存', ...)` の後に追加:
+
+```typescript
+  describe('edit モード - キャンセル', () => {
+    it('キャンセルすると編集内容が破棄され、view モードに戻る', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText="元のテキスト" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.clear(textarea)
+      await user.type(textarea, '変更後')
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+      expect(screen.getByText('元のテキスト')).toBeInTheDocument()
+      expect(
+        screen.queryByPlaceholderText('作品の感想を書く...'),
+      ).not.toBeInTheDocument()
+    })
+
+    it('null 状態から編集→キャンセルで empty モードに戻る', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+      expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: テスト実行、全 15 テストがパスすることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: PASS 15, FAIL 0
+
+Task 2 で `handleCancel` は既に実装済み。もし失敗したらデバッグする。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/components/ReviewSection/ReviewSection.test.tsx
+git commit -m "test(frontend): ReviewSection のキャンセル挙動テストを追加"
+```
+
+---
+
+## Task 6: エラーハンドリング実装（インラインエラー表示）
+
+**Files:**
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.tsx`
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.module.css`
+
+- [ ] **Step 1: エラーハンドリングのテストを追加**
+
+`ReviewSection.test.tsx` の末尾（`describe('edit モード - キャンセル', ...)` の後）に追加:
+
+```typescript
+  describe('エラーハンドリング', () => {
+    it('onSave が例外を投げた場合、エラーメッセージが表示される', async () => {
+      const user = userEvent.setup()
+      mockOnSave.mockRejectedValue(new Error('network error'))
+      render(<ReviewSection reviewText="text" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      expect(
+        await screen.findByText('保存に失敗しました。もう一度お試しください。'),
+      ).toBeInTheDocument()
+    })
+
+    it('保存失敗時は編集モードに留まり、入力内容が失われない', async () => {
+      const user = userEvent.setup()
+      mockOnSave.mockRejectedValue(new Error('fail'))
+      render(<ReviewSection reviewText="" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.type(textarea, '失敗テスト')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await screen.findByText(
+        '保存に失敗しました。もう一度お試しください。',
+      )
+      expect(screen.getByDisplayValue('失敗テスト')).toBeInTheDocument()
+    })
+
+    it('再試行時に前回のエラーがクリアされる', async () => {
+      const user = userEvent.setup()
+      mockOnSave
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce(undefined)
+      render(<ReviewSection reviewText="text" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await screen.findByText(
+        '保存に失敗しました。もう一度お試しください。',
+      )
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await waitFor(() => {
+        expect(
+          screen.queryByText('保存に失敗しました。もう一度お試しください。'),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
+```
+
+- [ ] **Step 2: テスト実行、エラー関連テスト 3 件のうち 1 件以上失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: エラーメッセージ要素が DOM に存在しないため失敗
+
+**注意:** 実は Task 2 で `saveError` ステートと `catch { setSaveError(...) }` までは書いてあるが、**描画部分で `saveError` を表示していない**ので失敗するはず。これは意図的。
+
+- [ ] **Step 3: `ReviewSection.tsx` の edit モード描画にエラー表示を追加**
+
+`ReviewSection.tsx` の `mode === 'edit'` の JSX 内、`<FormTextarea ... />` の直後・`<div className={styles.actions}>` の前に以下を追加:
+
+```typescript
+        {saveError && (
+          <p className={styles.errorMessage} role="alert">
+            {saveError}
+          </p>
+        )}
+```
+
+編集モード全体の return 文が次のようになる:
+
+```typescript
+  if (mode === 'edit') {
+    return (
+      <div className={styles.container}>
+        <FormTextarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="作品の感想を書く..."
+          rows={EDIT_ROWS}
+        />
+        {saveError && (
+          <p className={styles.errorMessage} role="alert">
+            {saveError}
+          </p>
+        )}
+        <div className={styles.actions}>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={handleCancel}
+            disabled={isSaving}
+          >
+            キャンセル
+          </Button>
+          <Button
+            variant="primary"
+            size="sm"
+            disabled={isSaving}
+            onClick={() => void handleSave()}
+          >
+            {isSaving ? '保存中...' : '保存'}
+          </Button>
+        </div>
+      </div>
+    )
+  }
+```
+
+- [ ] **Step 4: CSS にエラーメッセージ用スタイルを追加**
+
+`ReviewSection.module.css` の末尾に追加:
+
+```css
+.errorMessage {
+  margin: 0;
+  color: var(--color-error);
+  font-family: var(--font-body);
+  font-size: var(--font-size-label);
+}
+```
+
+- [ ] **Step 5: テスト実行、全 18 テストがパスすることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: PASS 18, FAIL 0
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/components/ReviewSection/
+git commit -m "feat(frontend): ReviewSection の保存エラー表示を実装"
+```
+
+---
+
+## Task 7: 親データ同期の useEffect 挙動を検証するテスト追加
+
+**Files:**
+- Modify: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`
+
+Task 2 で既に `useEffect` は実装済み。このタスクではその挙動を検証するテストを追加する。
+
+- [ ] **Step 1: 親データ同期テストを追加**
+
+`ReviewSection.test.tsx` の末尾に追加:
+
+```typescript
+  describe('親データ同期', () => {
+    it('編集中に親が reviewText を更新しても draft は上書きされない', async () => {
+      const user = userEvent.setup()
+      const { rerender } = render(
+        <ReviewSection reviewText="初期" onSave={mockOnSave} />,
+      )
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.clear(textarea)
+      await user.type(textarea, '編集中のテキスト')
+      // 親が reviewText を別の値で更新（例: 別タブで保存が発生）
+      rerender(
+        <ReviewSection reviewText="他から来た値" onSave={mockOnSave} />,
+      )
+      expect(screen.getByDisplayValue('編集中のテキスト')).toBeInTheDocument()
+    })
+  })
+```
+
+- [ ] **Step 2: テスト実行、全 19 テストがパスすることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection`
+Expected: PASS 19, FAIL 0
+
+Task 2 の `useEffect` は `mode !== 'edit'` の時のみ再同期するので、このテストは既に通るはず。もし失敗したら `useEffect` の依存配列を再確認する。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add frontend/src/components/ReviewSection/ReviewSection.test.tsx
+git commit -m "test(frontend): ReviewSection の親データ同期テストを追加"
+```
+
+---
+
+## Task 8: リント・型チェック・全体テスト実行
+
+**Files:**
+- なし（検証のみ）
+
+- [ ] **Step 1: ESLint を実行**
+
+Run: `cd frontend && npx eslint src/components/ReviewSection src/pages/WorkDetailPage`
+Expected: エラー・警告なし
+
+失敗した場合: 報告されたルール違反を修正してから次へ。
+
+- [ ] **Step 2: Prettier チェック**
+
+Run: `cd frontend && npx prettier --check src/components/ReviewSection src/pages/WorkDetailPage`
+Expected: All matched files use Prettier code style!
+
+失敗した場合: `npx prettier --write <該当ファイル>` で整形してから次へ。
+
+- [ ] **Step 3: TypeScript 型チェック**
+
+Run: `cd frontend && npx tsc --noEmit`
+Expected: エラーなし
+
+- [ ] **Step 4: ReviewSection 関連の全テスト実行**
+
+Run: `cd frontend && npx vitest run src/components/ReviewSection src/pages/WorkDetailPage`
+Expected: すべてパス
+
+- [ ] **Step 5: ファイル行数チェック**
+
+Run: `wc -l frontend/src/components/ReviewSection/ReviewSection.tsx`
+Expected: 200 行以下（CLAUDE.md のファイルサイズルール）
+
+- [ ] **Step 6: リンター修正があった場合のみコミット**
+
+変更がある場合:
+
+```bash
+git add frontend/src/components/ReviewSection/ frontend/src/pages/WorkDetailPage/
+git commit -m "style(frontend): ReviewSection の lint/format 調整"
+```
+
+変更がなければスキップ。
+
+---
+
+## Task 9: 開発サーバーで手動（または Playwright）動作確認
+
+**Files:**
+- なし（動作確認）
+
+動作確認は `recolly-workflow` の Step 5 に従って、IK さんに確認方法（手動 or Playwright MCP）を質問してから実施する。
+
+- [ ] **Step 1: IK さんに動作確認方法を AskUserQuestion で確認**
+
+質問テキスト例:
+> ReviewSection の動作確認を行います。以下のどちらで進めますか？
+> 1. 手動確認（ブラウザで操作する手順を案内）
+> 2. Playwright MCP で自動確認
+
+- [ ] **Step 2: 動作確認チェックリスト**
+
+確認観点（手動でも Playwright でも同じ）:
+
+1. **空状態**: 新規作品の詳細ページを開き、感想タブで「まだ感想が書かれていません」と「感想を書く」ボタンが表示される
+2. **empty → edit**: 「感想を書く」クリックでテキストエリアが表示される
+3. **保存**: テキスト入力して「保存」クリックで view モードに切り替わり、全文が表示される
+4. **改行保持**: 改行を含むテキストを保存し、view モードで改行が視覚的に保持されている
+5. **編集**: view モードで「編集」クリックで再度テキストエリアに戻る
+6. **キャンセル**: edit モードでテキストを変更して「キャンセル」クリックで編集内容が破棄される
+7. **長文**: 十分長いテキストを保存して、スクロールせずに全文が展開表示される（スクロールバーが出ない）
+8. **エラー**: ネットワークを切断して保存を試みて、エラーメッセージが表示される（手動時のみ）
+9. **モバイル**: 開発者ツールのデバイスモードでスマホサイズにし、タッチターゲット 44px 以上、レイアウト崩れなしを確認
+
+- [ ] **Step 3: 問題があればタスクを追加して修正、なければ次のステップへ**
+
+---
+
+## Task 10: ブランチ完了 + PR 作成
+
+**Files:**
+- なし（`superpowers:finishing-a-development-branch` スキルに従う）
+
+- [ ] **Step 1: `superpowers:finishing-a-development-branch` スキルを発動**
+
+このスキルが PR 作成までの手順をガイドする。Recolly の Git 運用ルール（`recolly-git-rules` スキル）も必要に応じて参照する。
+
+- [ ] **Step 2: PR タイトル候補**
+
+`feat(frontend): 作品詳細の感想タブを表示/編集モード化 (#146)`
+
+- [ ] **Step 3: PR 本文には以下を含める**
+
+- Issue リンク: `Closes #146`
+- スクショ（空状態・view モード・edit モード各1枚）
+- テスト結果（19 テストパス）
+- Spec / Plan へのリンク
+
+---
+
+## Self-Review
+
+### 1. スペック要件カバレッジ
+
+| スペック要件 | 実装タスク |
+|---|---|
+| 空状態メッセージ + ボタン | Task 2 |
+| view モード全文展開 + `white-space: pre-wrap` | Task 3 |
+| 「編集」ボタンで編集遷移 | Task 3 |
+| 「感想を書く」ボタンで編集遷移 | Task 2 |
+| edit モード `FormTextarea rows=8` | Task 2 |
+| 保存 / キャンセルボタン | Task 2, 4, 5 |
+| 保存中表示 | Task 4 |
+| 保存成功後に view に戻る | Task 4（useEffect 同期による） |
+| キャンセルで元のモードに戻る | Task 5 |
+| エラー時編集モードに留まる | Task 6 |
+| エラー再試行でエラークリア | Task 6 |
+| 編集中の親データ同期（上書き防止） | Task 7 |
+| Props 不変 | 全タスク（ReviewSectionProps 型を変更しない） |
+| `WorkDetailPage.tsx` 非変更 | 全タスク |
+| `useWorkDetail.ts` エラー伝播調整 | Task 1 |
+| デザイントークン使用 | Task 2, 3, 6（CSS ステップ） |
+| 200 行以内 | Task 8（行数チェック） |
+| 19 テストケース | Task 2-7（合計 5+5+3+2+3+1 = 19） |
+
+抜け漏れなし。
+
+### 2. プレースホルダースキャン
+
+- "TBD" / "TODO" / "implement later" なし ✓
+- 各ステップに具体コードまたはコマンドあり ✓
+- 「エラーハンドリング追加」のような曖昧な指示なし ✓
+
+### 3. 型・名前の整合性
+
+- `Mode = 'empty' | 'view' | 'edit'` が Task 2 で定義され、Task 3, 4, 5, 6 すべてで一貫使用 ✓
+- `handleStartEdit` / `handleCancel` / `handleSave` の関数名が統一 ✓
+- `SAVE_ERROR_MESSAGE` 定数が Task 2 で定義され、テストで参照される文字列と一致 ✓
+- `EDIT_ROWS = 8` 定数が Task 2 で定義、Spec の指定（rows=8）と一致 ✓

--- a/docs/superpowers/specs/2026-04-14-work-review-display-design.md
+++ b/docs/superpowers/specs/2026-04-14-work-review-display-design.md
@@ -1,0 +1,295 @@
+# 作品詳細ページ 感想タブ 表示/編集モード化 設計
+
+**日付:** 2026-04-14
+**対象機能:** 作品詳細ページ（`/works/:id`）の「感想」タブ内 `ReviewSection` コンポーネント
+**スコープ:** フロントエンドのみ（バックエンド変更なし）
+
+---
+
+## 背景
+
+現状、作品詳細ページの「感想」タブに配置されている `ReviewSection` コンポーネントは、`FormTextarea`（`rows=4` 固定）で感想を表示・編集している。長文の感想を書くと、テキストエリア内でスクロールが発生し、全文を一覧できない。
+
+ユーザーからの要望:
+
+> 動的に自分の感想が全部表示されるようにしたい。
+
+この「全部表示」を満たすため、感想を **表示モード（全文展開）** と **編集モード（テキストエリア）** に分離する。データモデル（`records.review_text` カラム）は変更しない。
+
+## 非目標
+
+以下は今回のスコープ外：
+
+- 複数の感想を時系列で保存する機能（1作品1感想を維持）
+- Markdown 等の書式対応
+- リッチテキストエディタ
+- 感想のバージョン履歴
+- 感想の公開/非公開設定
+- バックエンドのデータモデル変更
+
+## 要件
+
+### 機能要件
+
+1. **表示モード**: 感想がある場合、本文を全文展開して表示する。スクロールさせない。
+2. **編集モード**: 「編集」ボタンから切り替え、`FormTextarea` で編集できる。
+3. **空状態**: 感想が未記入（`null` または空文字）の場合、「まだ感想が書かれていません」メッセージと「感想を書く」ボタンを表示する。
+4. **改行保持**: プレーンテキストの改行を表示モードで保持する（`white-space: pre-wrap`）。
+5. **保存**: 編集モードで「保存」ボタンを押すと既存の `onSave` プロップを介してバックエンドに保存する。
+6. **キャンセル**: 編集モードで「キャンセル」ボタンを押すと、編集内容を破棄して元のモード（空状態 or 表示モード）に戻る。確認ダイアログは表示しない。
+7. **エラーハンドリング**: 保存失敗時はエラーメッセージを表示し、編集モードに留まる（入力内容を失わない）。
+
+### 非機能要件
+
+- **API互換性**: `ReviewSection` の外部Props（`reviewText`, `onSave`）は変更しない。
+- **バックエンド非変更**: `records.review_text` カラムと `PATCH /api/v1/records/:id` は変更しない。
+- **デザイントークン遵守**: すべてのスタイル値は `tokens.css` の CSS 変数を使用する（CLAUDE.md 参照）。
+- **ファイルサイズ**: `ReviewSection.tsx` は 200 行以内に収める（CLAUDE.md 参照）。
+- **レスポンシブ**: モバイル（〜768px）でも自然に動作する。タッチターゲット 44px 以上。
+
+---
+
+## コンポーネント構造（方針1: 単一コンポーネント内での状態分岐）
+
+### 変更対象ファイル
+
+- `frontend/src/components/ReviewSection/ReviewSection.tsx`（機能拡張）
+- `frontend/src/components/ReviewSection/ReviewSection.module.css`（スタイル追加）
+- `frontend/src/components/ReviewSection/ReviewSection.test.tsx`（テスト書き換え + 追加）
+
+### 変更しないファイル
+
+- `frontend/src/pages/WorkDetailPage/WorkDetailPage.tsx`
+- `frontend/src/pages/WorkDetailPage/useWorkDetail.ts`
+- バックエンドのファイル全般
+
+### Props（変更なし）
+
+```typescript
+type ReviewSectionProps = {
+  reviewText: string | null
+  onSave: (text: string) => Promise<void> | void
+}
+```
+
+### 内部状態
+
+```typescript
+type Mode = 'empty' | 'view' | 'edit'
+
+const [mode, setMode] = useState<Mode>(initialMode)
+const [draft, setDraft] = useState<string>(reviewText ?? '')
+const [isSaving, setIsSaving] = useState<boolean>(false)
+const [saveError, setSaveError] = useState<string | null>(null)
+```
+
+初期モードは `reviewText` の値から計算する：
+
+```typescript
+const initialMode: Mode = reviewText ? 'view' : 'empty'
+```
+
+### 状態遷移
+
+```
+empty  --[「感想を書く」クリック]-------------------->  edit
+view   --[「編集」クリック]-------------------------->  edit
+edit   --[保存成功（reviewText が更新される）]------->  view
+edit   --[キャンセル]----------------------------->  元のモード（empty or view）
+edit   --[保存失敗]---------------------------------->  edit（エラー表示）
+```
+
+### 親データ同期
+
+```typescript
+useEffect(() => {
+  // 編集中でなければ、親の値に mode と draft を追従させる
+  if (mode !== 'edit') {
+    setMode(reviewText ? 'view' : 'empty')
+    setDraft(reviewText ?? '')
+  }
+}, [reviewText])
+```
+
+`mode === 'edit'` の時は親からの `reviewText` 変化を無視する（ユーザーの入力を上書きしないため）。
+
+---
+
+## データフロー
+
+### 保存フロー
+
+1. `edit` モードで `FormTextarea` に入力 → `setDraft(value)`
+2. 「保存」ボタンをクリック
+3. `setIsSaving(true)`, `setSaveError(null)`
+4. `await onSave(draft)` を呼ぶ
+5. 成功時: 親が `record.review_text` を更新 → `reviewText` プロップが変化 → `useEffect` が発火 → `mode` が `'view'` に戻る
+6. 失敗時: `setSaveError('保存に失敗しました。もう一度お試しください。')`、`mode` は `'edit'` のまま
+7. `finally` で `setIsSaving(false)`
+
+### キャンセルフロー
+
+1. `edit` モードで「キャンセル」ボタンをクリック
+2. `setDraft(reviewText ?? '')` で編集内容を破棄
+3. `setMode(reviewText ? 'view' : 'empty')` で元のモードに戻す
+4. `setSaveError(null)` でエラー表示をクリア
+
+### 空状態からの編集開始
+
+1. `empty` モードで「感想を書く」ボタンをクリック
+2. `setMode('edit')`, `setDraft('')`
+
+### 表示モードからの編集開始
+
+1. `view` モードで「編集」ボタンをクリック
+2. `setMode('edit')`, `setDraft(reviewText ?? '')`
+
+---
+
+## UI 仕様
+
+### 共通ルール
+
+- スタイル値はすべて `tokens.css` の CSS 変数を使用（色、スペーシング、角丸、フォント）
+- フォーム入力は `FormTextarea` のみ使用（生の `<textarea>` 禁止）
+- ボタンは `Button` コンポーネントを使用
+
+### `empty` モード
+
+- 外枠: 薄い罫線または点線のコンテナ
+- メッセージ: 「まだ感想が書かれていません」（`--color-text-secondary` 相当）
+- ボタン: `<Button variant="primary" size="sm">感想を書く</Button>`
+- 中央揃え、余白は `var(--spacing-*)` で調整
+
+### `view` モード
+
+- 右上に編集ボタン: `<Button variant="secondary" size="sm">編集</Button>`
+- 本文エリア: `<p>` または `<div>` に以下のスタイル
+  - `white-space: pre-wrap`（改行保持）
+  - `line-height`: 読みやすい値（既存トークンを優先、なければ 1.8 程度）
+  - `color: var(--color-text)`
+  - 背景・余白は既存 section と合わせる
+- 本文は最大幅でコンテナに追従、縦は内容に合わせて自動伸張
+
+### `edit` モード
+
+- `<FormTextarea rows={8}>` （従来の `rows=4` から拡大）
+- `draft` の値をバインド、`onChange` で `setDraft` を呼ぶ
+- エラーメッセージ: `saveError` が非 null の時、テキストエリアの下、ボタンの上に1行表示
+- ボタン配置: 右寄せ
+  - `<Button variant="secondary" size="sm" onClick={handleCancel}>キャンセル</Button>`
+  - `<Button variant="primary" size="sm" disabled={isSaving} onClick={handleSave}>{isSaving ? '保存中...' : '保存'}</Button>`
+- 編集モードでは保存ボタンを常に表示（従来の「dirty 時のみ表示」ロジックは廃止）
+
+### レスポンシブ
+
+- スマホ: タッチターゲット 44px 以上を維持（既存の Button コンポーネントで担保）
+- テキストエリアの高さはスマホでも十分な領域を確保
+
+---
+
+## エラーハンドリング
+
+### 保存失敗
+
+1. `onSave` が Promise を reject、または例外を throw した場合に `catch` で捕捉
+2. `saveError` に日本語メッセージをセット（「保存に失敗しました。もう一度お試しください。」）
+3. `mode` は `'edit'` のまま留まる（入力内容を失わない）
+4. ユーザーは「保存」ボタンを再度押すことで再試行できる
+5. 再試行時は先頭で `setSaveError(null)` を呼び、前回のエラー表示をクリア
+
+### 親ハンドラ側の調整
+
+現状の `useWorkDetail.handleReviewTextSave` が例外を throw するかどうかは実装時に確認する。throw しない場合（エラーが握りつぶされる場合）は、親側で throw するように調整が必要。この調整は実装プラン作成時に判断する。
+
+### 既存のエラー表示コンポーネント再利用
+
+`frontend/src/components/ui/ActionErrorCard/ActionErrorCard.tsx` が既存にある。これが流用できそうなら再利用し、そうでなければシンプルなテキスト要素でエラーを表示する。判断は実装プラン作成時に行う。
+
+---
+
+## テスト観点
+
+### テストフレームワーク
+
+Vitest + React Testing Library + `@testing-library/user-event`。
+ファイル: `frontend/src/components/ReviewSection/ReviewSection.test.tsx`（既存拡張）。
+
+### テストケース一覧
+
+#### `empty` モード
+
+1. `reviewText` が `null` の時、「まだ感想が書かれていません」メッセージが表示される
+2. `reviewText` が空文字の時、空状態メッセージが表示される
+3. 空状態で「感想を書く」ボタンをクリックすると編集モードに切り替わる
+4. 空状態では「編集」ボタンも「保存」ボタンも表示されない
+
+#### `view` モード
+
+5. `reviewText` に値がある時、本文が全文表示される
+6. `reviewText` に改行を含むテキストが渡された時、改行が視覚的に保持される
+7. `view` モードで「編集」ボタンをクリックすると編集モードに切り替わる
+8. `view` モードではテキストエリアは表示されない
+
+#### `edit` モード
+
+9. 編集モードでテキストエリアに既存の `reviewText` が入っている
+10. テキストを変更して「保存」ボタンをクリックすると `onSave` が新しいテキストで呼ばれる
+11. 保存中は「保存」ボタンが「保存中...」表示になり disabled になる
+12. 保存成功後、新しい `reviewText` がプロップで渡されると `view` モードに戻る
+13. 「キャンセル」ボタンをクリックすると編集内容が破棄され、元のモードに戻る
+14. `reviewText` が `null` の状態から編集モードに入り、キャンセルすると `empty` に戻る
+15. `reviewText` に値がある状態から編集モードに入り、キャンセルすると `view` に戻る
+
+#### エラーハンドリング
+
+16. `onSave` が例外を投げた場合、エラーメッセージが表示される
+17. エラー表示後、もう一度「保存」ボタンを押すとエラーがクリアされて再試行される
+18. 保存失敗時は編集モードに留まる（入力内容が失われない）
+
+#### 編集中の親データ同期
+
+19. 編集中（`mode === 'edit'`）に親から `reviewText` が更新されても、`draft` は上書きされない
+
+### 既存テストの取り扱い
+
+現行の `ReviewSection.test.tsx` には 5 つのテストがある。すべて設計変更に伴い書き換える：
+
+- 「感想テキストを表示する」→ 表示モードでの表示確認に変更
+- 「未記入時にプレースホルダーを表示する」→ 空状態メッセージ確認に変更
+- 「テキスト変更時に保存ボタンを表示する」→ 編集モードで常に保存ボタン表示に変更
+- 「テキスト未変更時は保存ボタンを非表示にする」→ 削除（編集モードでは常に表示するため）
+- 「保存ボタン押下時に onSave が呼ばれる」→ 編集モードに入ってから実行する流れに変更
+
+### WorkDetailPage.test.tsx の扱い
+
+外部 API が変わらないため、`WorkDetailPage.test.tsx` は変更しない。テストが失敗する場合は方針1の前提（外部 API 不変）が崩れているため、実装プラン段階で警告する。
+
+### Storybook
+
+Recolly は Storybook を導入していないため対応不要。
+
+---
+
+## 実装方針の要約
+
+| 観点 | 決定 |
+| --- | --- |
+| 要求の解釈 | 単一感想を「表示モード」と「編集モード」に分ける（複数感想や書式対応は別スコープ） |
+| 編集モード切替方式 | インライン切替（モーダル/別ページは不採用） |
+| 書式対応 | プレーンテキスト + 改行保持（`white-space: pre-wrap`） |
+| 空状態 | 「感想を書く」ボタン付きの空状態メッセージ |
+| 実装構造 | `ReviewSection` 内で `mode` 分岐（コンポーネント分割せず） |
+| バックエンド | 変更なし |
+| 外部 API | `ReviewSectionProps` 変更なし |
+| エラー時 | 編集モードに留まり、エラーメッセージ表示 |
+| キャンセル確認 | なし（無言で破棄） |
+
+---
+
+## 参考: 決定の根拠
+
+- **単一コンポーネント内分岐を選んだ理由**: 今回のタスクは振る舞いの変更であり、再利用性を高める作業ではない。`ReviewSection` の Props を維持すれば呼び出し側の変更が不要で、副作用が最小化される。現行 45 行 → 推定 120 行程度で CLAUDE.md の 200 行ルール内に収まる。将来コンポーネント分割が必要になれば、その時点でのリファクタが可能。
+- **プレーンテキストを選んだ理由**: 既存カラム構造の変更不要、ライブラリ追加不要、サニタイズ検討不要で最小実装。Markdown 対応は別イシューとして切り出す方がスコープがブレない（YAGNI）。
+- **空状態にボタンを設けた理由**: 誤タップを防ぎ、表示モードと編集モードの境界を明確にする。Recolly 既存の EmptyState パターンとも揃えやすい。
+- **キャンセル確認なしを選んだ理由**: Recolly の他の編集 UI と一貫性を保つため。

--- a/frontend/src/components/ReviewSection/ReviewSection.module.css
+++ b/frontend/src/components/ReviewSection/ReviewSection.module.css
@@ -8,8 +8,8 @@
 .container textarea {
   border: var(--border-width) var(--border-style) var(--color-border-light);
   border-radius: var(--radius-sm);
-  padding: 12px;
-  min-height: 80px;
+  padding: var(--spacing-md);
+  min-height: 160px;
   background: var(--color-bg-white);
 }
 
@@ -21,4 +21,25 @@
 .actions {
   display: flex;
   justify-content: flex-end;
+  gap: var(--spacing-sm);
+}
+
+/* empty モード */
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-md);
+  padding: var(--spacing-xl);
+  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-white);
+}
+
+.emptyMessage {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
 }

--- a/frontend/src/components/ReviewSection/ReviewSection.module.css
+++ b/frontend/src/components/ReviewSection/ReviewSection.module.css
@@ -43,3 +43,28 @@
   font-family: var(--font-body);
   font-size: var(--font-size-body);
 }
+
+/* view モード */
+.viewContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.viewActions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.viewText {
+  margin: 0;
+  padding: var(--spacing-md);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  font-size: var(--font-size-body);
+  line-height: var(--line-height-relaxed);
+  white-space: pre-wrap;
+  background: var(--color-bg-white);
+  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-sm);
+}

--- a/frontend/src/components/ReviewSection/ReviewSection.module.css
+++ b/frontend/src/components/ReviewSection/ReviewSection.module.css
@@ -68,3 +68,11 @@
   border: var(--border-width-thin) var(--border-style) var(--color-border-light);
   border-radius: var(--radius-sm);
 }
+
+/* エラーメッセージ */
+.errorMessage {
+  margin: 0;
+  color: var(--color-error);
+  font-family: var(--font-body);
+  font-size: var(--font-size-label);
+}

--- a/frontend/src/components/ReviewSection/ReviewSection.test.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.test.tsx
@@ -139,4 +139,44 @@ describe('ReviewSection', () => {
       expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
     })
   })
+
+  describe('エラーハンドリング', () => {
+    it('onSave が例外を投げた場合、エラーメッセージが表示される', async () => {
+      const user = userEvent.setup()
+      mockOnSave.mockRejectedValue(new Error('network error'))
+      render(<ReviewSection reviewText="text" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      expect(
+        await screen.findByText('保存に失敗しました。もう一度お試しください。'),
+      ).toBeInTheDocument()
+    })
+
+    it('保存失敗時は編集モードに留まり、入力内容が失われない', async () => {
+      const user = userEvent.setup()
+      mockOnSave.mockRejectedValue(new Error('fail'))
+      render(<ReviewSection reviewText="" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.type(textarea, '失敗テスト')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await screen.findByText('保存に失敗しました。もう一度お試しください。')
+      expect(screen.getByDisplayValue('失敗テスト')).toBeInTheDocument()
+    })
+
+    it('再試行時に前回のエラーがクリアされる', async () => {
+      const user = userEvent.setup()
+      mockOnSave.mockRejectedValueOnce(new Error('fail')).mockResolvedValueOnce(undefined)
+      render(<ReviewSection reviewText="text" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await screen.findByText('保存に失敗しました。もう一度お試しください。')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await waitFor(() => {
+        expect(
+          screen.queryByText('保存に失敗しました。もう一度お試しください。'),
+        ).not.toBeInTheDocument()
+      })
+    })
+  })
 })

--- a/frontend/src/components/ReviewSection/ReviewSection.test.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.test.tsx
@@ -1,41 +1,43 @@
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ReviewSection } from './ReviewSection'
 
 describe('ReviewSection', () => {
-  const mockOnSave = vi.fn()
+  let mockOnSave: ReturnType<typeof vi.fn>
 
-  it('感想テキストを表示する', () => {
-    render(<ReviewSection reviewText="素晴らしい作品" onSave={mockOnSave} />)
-    expect(screen.getByDisplayValue('素晴らしい作品')).toBeInTheDocument()
+  beforeEach(() => {
+    mockOnSave = vi.fn().mockResolvedValue(undefined)
   })
 
-  it('未記入時にプレースホルダーを表示する', () => {
-    render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
-    expect(screen.getByPlaceholderText('作品の感想を書く...')).toBeInTheDocument()
-  })
+  describe('empty モード', () => {
+    it('reviewText が null の時、空状態メッセージが表示される', () => {
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
+    })
 
-  it('テキスト変更時に保存ボタンを表示する', async () => {
-    render(<ReviewSection reviewText="" onSave={mockOnSave} />)
-    const textarea = screen.getByPlaceholderText('作品の感想を書く...')
-    await userEvent.type(textarea, 'テスト')
-    expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
-  })
+    it('reviewText が空文字の時、空状態メッセージが表示される', () => {
+      render(<ReviewSection reviewText="" onSave={mockOnSave} />)
+      expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
+    })
 
-  it('テキスト未変更時は保存ボタンを非表示にする', () => {
-    render(<ReviewSection reviewText="既存テキスト" onSave={mockOnSave} />)
-    expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument()
-  })
+    it('「感想を書く」ボタンが表示される', () => {
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      expect(screen.getByRole('button', { name: '感想を書く' })).toBeInTheDocument()
+    })
 
-  it('保存ボタン押下時にonSaveが呼ばれる', async () => {
-    mockOnSave.mockResolvedValue(undefined)
-    render(<ReviewSection reviewText="" onSave={mockOnSave} />)
-    const textarea = screen.getByPlaceholderText('作品の感想を書く...')
-    await userEvent.type(textarea, '新しい感想')
-    await userEvent.click(screen.getByRole('button', { name: '保存' }))
-    await waitFor(() => {
-      expect(mockOnSave).toHaveBeenCalledWith('新しい感想')
+    it('「感想を書く」クリックで編集モードに切り替わる', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      expect(screen.getByPlaceholderText('作品の感想を書く...')).toBeInTheDocument()
+      expect(screen.getByRole('button', { name: '保存' })).toBeInTheDocument()
+    })
+
+    it('空状態では「編集」「保存」ボタンが表示されない', () => {
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      expect(screen.queryByRole('button', { name: '編集' })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument()
     })
   })
 })

--- a/frontend/src/components/ReviewSection/ReviewSection.test.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.test.tsx
@@ -117,4 +117,26 @@ describe('ReviewSection', () => {
       expect(screen.queryByPlaceholderText('作品の感想を書く...')).not.toBeInTheDocument()
     })
   })
+
+  describe('edit モード - キャンセル', () => {
+    it('キャンセルすると編集内容が破棄され、view モードに戻る', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText="元のテキスト" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.clear(textarea)
+      await user.type(textarea, '変更後')
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+      expect(screen.getByText('元のテキスト')).toBeInTheDocument()
+      expect(screen.queryByPlaceholderText('作品の感想を書く...')).not.toBeInTheDocument()
+    })
+
+    it('null 状態から編集→キャンセルで empty モードに戻る', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+      expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/ReviewSection/ReviewSection.test.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.test.tsx
@@ -179,4 +179,18 @@ describe('ReviewSection', () => {
       })
     })
   })
+
+  describe('親データ同期', () => {
+    it('編集中に親が reviewText を更新しても draft は上書きされない', async () => {
+      const user = userEvent.setup()
+      const { rerender } = render(<ReviewSection reviewText="初期" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.clear(textarea)
+      await user.type(textarea, '編集中のテキスト')
+      // 親が reviewText を別の値で更新（例: 別タブで保存が発生）
+      rerender(<ReviewSection reviewText="他から来た値" onSave={mockOnSave} />)
+      expect(screen.getByDisplayValue('編集中のテキスト')).toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/ReviewSection/ReviewSection.test.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.test.tsx
@@ -40,4 +40,36 @@ describe('ReviewSection', () => {
       expect(screen.queryByRole('button', { name: '保存' })).not.toBeInTheDocument()
     })
   })
+
+  describe('view モード', () => {
+    it('reviewText に値がある時、本文が表示される', () => {
+      render(<ReviewSection reviewText="素晴らしい作品" onSave={mockOnSave} />)
+      expect(screen.getByText('素晴らしい作品')).toBeInTheDocument()
+    })
+
+    it('改行を含むテキストで pre-wrap スタイルが適用される', () => {
+      const text = '1行目\n2行目\n3行目'
+      const { container } = render(<ReviewSection reviewText={text} onSave={mockOnSave} />)
+      const textEl = container.querySelector('p')
+      expect(textEl?.textContent).toBe(text)
+      expect(textEl?.className).toMatch(/viewText/)
+    })
+
+    it('「編集」ボタンが表示される', () => {
+      render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      expect(screen.getByRole('button', { name: '編集' })).toBeInTheDocument()
+    })
+
+    it('「編集」クリックで編集モードに切り替わり、既存テキストが入っている', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      expect(screen.getByDisplayValue('感想')).toBeInTheDocument()
+    })
+
+    it('view モードではテキストエリアが表示されない', () => {
+      render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      expect(screen.queryByPlaceholderText('作品の感想を書く...')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/frontend/src/components/ReviewSection/ReviewSection.test.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ReviewSection } from './ReviewSection'
@@ -69,6 +69,51 @@ describe('ReviewSection', () => {
 
     it('view モードではテキストエリアが表示されない', () => {
       render(<ReviewSection reviewText="感想" onSave={mockOnSave} />)
+      expect(screen.queryByPlaceholderText('作品の感想を書く...')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('edit モード - 保存', () => {
+    it('保存ボタンをクリックすると onSave が新しいテキストで呼ばれる', async () => {
+      const user = userEvent.setup()
+      render(<ReviewSection reviewText={null} onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.type(textarea, '新しい感想')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await waitFor(() => {
+        expect(mockOnSave).toHaveBeenCalledWith('新しい感想')
+      })
+    })
+
+    it('保存中は保存ボタンが「保存中...」表示で disabled になる', async () => {
+      const user = userEvent.setup()
+      let resolveSave: (() => void) | undefined
+      mockOnSave.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            resolveSave = resolve
+          }),
+      )
+      render(<ReviewSection reviewText="text" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '編集' }))
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      const savingBtn = await screen.findByRole('button', { name: '保存中...' })
+      expect(savingBtn).toBeDisabled()
+      resolveSave?.()
+    })
+
+    it('保存成功後、親が reviewText を更新すると view モードに戻る', async () => {
+      const user = userEvent.setup()
+      const { rerender } = render(<ReviewSection reviewText="" onSave={mockOnSave} />)
+      await user.click(screen.getByRole('button', { name: '感想を書く' }))
+      const textarea = screen.getByPlaceholderText('作品の感想を書く...')
+      await user.type(textarea, '保存後')
+      await user.click(screen.getByRole('button', { name: '保存' }))
+      await waitFor(() => expect(mockOnSave).toHaveBeenCalled())
+      // 親が reviewText を更新したことをシミュレート
+      rerender(<ReviewSection reviewText="保存後" onSave={mockOnSave} />)
+      expect(screen.getByText('保存後')).toBeInTheDocument()
       expect(screen.queryByPlaceholderText('作品の感想を書く...')).not.toBeInTheDocument()
     })
   })

--- a/frontend/src/components/ReviewSection/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.tsx
@@ -19,7 +19,7 @@ export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
   const [mode, setMode] = useState<Mode>(() => computeInitialMode(reviewText))
   const [draft, setDraft] = useState<string>(reviewText ?? '')
   const [isSaving, setIsSaving] = useState(false)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Task 3 の view モード実装で使用予定
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Task 6 のエラー表示実装で JSX に描画予定
   const [saveError, setSaveError] = useState<string | null>(null)
 
   // 親から reviewText が変わった時、編集中でなければ追従する

--- a/frontend/src/components/ReviewSection/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { Button } from '../ui/Button/Button'
 import { FormTextarea } from '../ui/FormTextarea/FormTextarea'
 import styles from './ReviewSection.module.css'
@@ -8,37 +8,91 @@ type ReviewSectionProps = {
   onSave: (text: string) => Promise<void> | void
 }
 
-export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
-  const [text, setText] = useState(reviewText ?? '')
-  const [isSaving, setIsSaving] = useState(false)
+type Mode = 'empty' | 'view' | 'edit'
 
-  // テキストが元の値から変更されたかどうか
-  const isDirty = text !== (reviewText ?? '')
+const EDIT_ROWS = 8
+const SAVE_ERROR_MESSAGE = '保存に失敗しました。もう一度お試しください。'
+
+const computeInitialMode = (reviewText: string | null): Mode => (reviewText ? 'view' : 'empty')
+
+export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
+  const [mode, setMode] = useState<Mode>(() => computeInitialMode(reviewText))
+  const [draft, setDraft] = useState<string>(reviewText ?? '')
+  const [isSaving, setIsSaving] = useState(false)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Task 3 の view モード実装で使用予定
+  const [saveError, setSaveError] = useState<string | null>(null)
+
+  // 親から reviewText が変わった時、編集中でなければ追従する
+  useEffect(() => {
+    if (mode !== 'edit') {
+      setMode(computeInitialMode(reviewText))
+      setDraft(reviewText ?? '')
+    }
+    // mode を依存配列に含めない: 編集中に mode が変わるたびに再同期するのを避けるため
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [reviewText])
+
+  const handleStartEdit = useCallback(() => {
+    setDraft(reviewText ?? '')
+    setSaveError(null)
+    setMode('edit')
+  }, [reviewText])
+
+  const handleCancel = useCallback(() => {
+    setDraft(reviewText ?? '')
+    setSaveError(null)
+    setMode(computeInitialMode(reviewText))
+  }, [reviewText])
 
   const handleSave = useCallback(async () => {
     setIsSaving(true)
+    setSaveError(null)
     try {
-      await onSave(text)
+      await onSave(draft)
+      // 保存成功: edit モードを抜けて、draft の内容に応じて view / empty に遷移
+      // useEffect は mode === 'edit' の時は同期をスキップするため、ここで明示的に遷移する
+      // 親の reviewText 更新と一緒にバッチされるので、中間状態は描画されない
+      setMode(draft ? 'view' : 'empty')
+    } catch {
+      setSaveError(SAVE_ERROR_MESSAGE)
     } finally {
       setIsSaving(false)
     }
-  }, [text, onSave])
+  }, [draft, onSave])
 
-  return (
-    <div className={styles.container}>
-      <FormTextarea
-        value={text}
-        onChange={(e) => setText(e.target.value)}
-        placeholder="作品の感想を書く..."
-        rows={4}
-      />
-      {isDirty && (
+  if (mode === 'empty') {
+    return (
+      <div className={styles.empty}>
+        <p className={styles.emptyMessage}>まだ感想が書かれていません</p>
+        <Button variant="primary" size="sm" onClick={handleStartEdit}>
+          感想を書く
+        </Button>
+      </div>
+    )
+  }
+
+  // 現時点では edit は後続 Task で動作検証する暫定実装
+  if (mode === 'edit') {
+    return (
+      <div className={styles.container}>
+        <FormTextarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder="作品の感想を書く..."
+          rows={EDIT_ROWS}
+        />
         <div className={styles.actions}>
+          <Button variant="secondary" size="sm" onClick={handleCancel} disabled={isSaving}>
+            キャンセル
+          </Button>
           <Button variant="primary" size="sm" disabled={isSaving} onClick={() => void handleSave()}>
             {isSaving ? '保存中...' : '保存'}
           </Button>
         </div>
-      )}
-    </div>
-  )
+      </div>
+    )
+  }
+
+  // view モード（Task 3 で本実装）
+  return null
 }

--- a/frontend/src/components/ReviewSection/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.tsx
@@ -19,7 +19,6 @@ export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
   const [mode, setMode] = useState<Mode>(() => computeInitialMode(reviewText))
   const [draft, setDraft] = useState<string>(reviewText ?? '')
   const [isSaving, setIsSaving] = useState(false)
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Task 6 のエラー表示実装で JSX に描画予定
   const [saveError, setSaveError] = useState<string | null>(null)
 
   // 親から reviewText が変わった時、編集中でなければ追従する
@@ -81,6 +80,11 @@ export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
           placeholder="作品の感想を書く..."
           rows={EDIT_ROWS}
         />
+        {saveError && (
+          <p className={styles.errorMessage} role="alert">
+            {saveError}
+          </p>
+        )}
         <div className={styles.actions}>
           <Button variant="secondary" size="sm" onClick={handleCancel} disabled={isSaving}>
             キャンセル

--- a/frontend/src/components/ReviewSection/ReviewSection.tsx
+++ b/frontend/src/components/ReviewSection/ReviewSection.tsx
@@ -93,6 +93,15 @@ export function ReviewSection({ reviewText, onSave }: ReviewSectionProps) {
     )
   }
 
-  // view モード（Task 3 で本実装）
-  return null
+  // view モード
+  return (
+    <div className={styles.viewContainer}>
+      <div className={styles.viewActions}>
+        <Button variant="secondary" size="sm" onClick={handleStartEdit}>
+          編集
+        </Button>
+      </div>
+      <p className={styles.viewText}>{reviewText}</p>
+    </div>
+  )
 }

--- a/frontend/src/pages/WorkDetailPage/WorkDetailPage.test.tsx
+++ b/frontend/src/pages/WorkDetailPage/WorkDetailPage.test.tsx
@@ -126,7 +126,8 @@ describe('WorkDetailPage', () => {
     })
     // 感想タブに切り替え
     await user.click(screen.getByRole('button', { name: '感想' }))
-    expect(screen.getByPlaceholderText('作品の感想を書く...')).toBeInTheDocument()
+    // review_text が null のため、ReviewSection は empty モードを表示する
+    expect(screen.getByText('まだ感想が書かれていません')).toBeInTheDocument()
   })
 
   it('感想タブでアニメの場合は話数ごとの感想セクションが表示される', async () => {

--- a/frontend/src/pages/WorkDetailPage/useWorkDetail.ts
+++ b/frontend/src/pages/WorkDetailPage/useWorkDetail.ts
@@ -117,9 +117,13 @@ export function useWorkDetail() {
 
   const handleReviewTextSave = useCallback(
     async (text: string) => {
-      await updateRecord({ review_text: text })
+      if (!state.record) return
+      // 注意: updateRecord を経由するとエラーが握りつぶされるので、
+      // ReviewSection 側でエラー表示できるように直接呼び出して例外を伝播させる
+      const res = await recordsApi.update(state.record.id, { review_text: text })
+      setState((prev) => ({ ...prev, record: res.record }))
     },
-    [updateRecord],
+    [state.record],
   )
 
   const handleRewatchCountChange = useCallback(


### PR DESCRIPTION
## Summary

作品詳細ページ (`/works/:id`) の感想タブ内 `ReviewSection` を `empty` / `view` / `edit` の 3 モードに分離し、長文感想を全文展開表示できるようにした。

- 感想が未記入の時は「まだ感想が書かれていません」+「感想を書く」ボタンの空状態表示
- 感想が記入済みの時は `white-space: pre-wrap` で改行保持しつつ全文展開表示
- 「編集」ボタンでインラインにテキストエリア（`rows=8`）に切り替わり、保存/キャンセル可能
- 保存失敗時はインラインでエラーメッセージ表示、編集内容は失われない
- `ReviewSectionProps` は不変のため `WorkDetailPage.tsx` は一切変更していない
- バックエンド・データモデルは変更なし

Closes #146

## 変更ファイル

- `frontend/src/components/ReviewSection/ReviewSection.tsx` — 3モード内部分岐
- `frontend/src/components/ReviewSection/ReviewSection.test.tsx` — 19 テスト追加
- `frontend/src/components/ReviewSection/ReviewSection.module.css` — empty/view/error 用スタイル追加
- `frontend/src/pages/WorkDetailPage/useWorkDetail.ts` — `handleReviewTextSave` のエラー伝播修正（`updateRecord` の握りつぶしを経由しない）
- `frontend/src/pages/WorkDetailPage/WorkDetailPage.test.tsx` — 感想タブ切替テストを empty モード表示の確認に更新

## 参照ドキュメント

- Spec: `docs/superpowers/specs/2026-04-14-work-review-display-design.md`
- Plan: `docs/superpowers/plans/2026-04-14-work-review-display.md`

## Test Plan

- [x] ReviewSection ユニットテスト 19/19 パス（empty 5 + view 5 + edit保存 3 + キャンセル 2 + エラー 3 + 親同期 1）
- [x] WorkDetailPage ユニットテスト 16/16 パス
- [x] フロントエンド全テスト 510/510 パス
- [x] ESLint / Prettier / TypeScript チェックパス
- [x] Playwright MCP で手動動作確認: empty → edit → 保存 → view → 編集 → キャンセル → view の一連フロー
- [x] 改行保持を実 DOM の `white-space: pre-wrap` と textarea value の `\n` 含有で確認
- [x] ファイルサイズ 111 行（200 行制限内）

🤖 Generated with [Claude Code](https://claude.com/claude-code)