### PR TITLE
docs(todo): フェーズ5 計測基盤の項目を Phase 1 実装済みに更新

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -118,9 +118,14 @@
 **前提文書**: `docs/product-marketing-context.md`（2026-04-13 作成）
 
 ### 計測基盤（最優先）
-- [ ] GA4 などの計測基盤を導入（`analytics-tracking` スキル）
-- [ ] 計測すべき指標の定義: 登録ユーザー数、記録件数、**ジャンル横断率**、継続率、DAU/WAU/MAU
-- [ ] イベント定義（登録、初回記録、3作品到達、ジャンル横断記録、再訪）
+- [x] プロダクト分析ツールの選定 — PostHog を採用（ADR-0041）
+- [x] 計測基盤を導入（Phase 1: `$pageview` / `$identify` / `signup_completed` / `record_created`）— PR #145, Issue #143
+- [x] 計測すべき指標の定義: 登録ユーザー数、記録件数、**ジャンル横断率**、継続率、DAU/WAU/MAU（Spec §2.3 で導出方法を定義）
+- [x] Phase 1 イベント定義（登録、初回記録、ジャンル横断記録の基点）— PR #145
+- [x] プライバシーポリシーページ `/privacy` とフッター導線 — PR #145
+- [ ] PostHog Dashboard / Insight の作成（特に「ジャンル横断率」カスタム指標） — Phase 1 実装後タスク
+- [ ] Phase 2 イベント追加（`search_performed` / `episode_progress_updated` / `record_status_changed` / `recommendation_clicked`） — 別仕様書で扱う
+- [ ] Phase 3 イベント追加（3作品到達、再訪、討論投稿、レコメンドクリック等） — 運用データを見てから判断
 
 ### ランディングページ
 - [ ] 非ログインユーザー向けLP作成（現状は `/` → LoginPage 直行のため訴求面がない）


### PR DESCRIPTION
## Summary

PR #145 で PostHog 導入 (Phase 1: `\$pageview` / `\$identify` / `signup_completed` / `record_created`) が完了したので、`docs/TODO.md` フェーズ5「計測基盤」の該当項目をチェック済みに更新しました。

### 変更点

- ツール選定 / 計測基盤導入 / 指標定義 / Phase 1 イベント定義 / プライバシーポリシー導線 をチェック済みに
- 未着手として以下を追加:
  - PostHog Dashboard / Insight 作成（「ジャンル横断率」カスタム指標）
  - Phase 2 イベント（\`search_performed\` 他）
  - Phase 3 イベント（3作品到達 / 再訪 他）

## Test Plan

- [x] ドキュメントのみの変更のため、テストは不要
- [x] Markdown の構造が壊れていないか目視確認

## 関連

- Issue: #143
- PR: #145 (analytics-tracking Phase 1 実装)