### PR TITLE
fix: 外部API断続障害時に空結果が長時間キャッシュされる問題を修正

### DIFF
--- a/backend/app/services/external_apis/google_books_adapter.rb
+++ b/backend/app/services/external_apis/google_books_adapter.rb
@@ -9,15 +9,26 @@ module ExternalApis
     end
 
     def search(query, media_type: nil) # rubocop:disable Lint/UnusedMethodArgument -- BaseAdapterインターフェース準拠
-      # intitle: でタイトル検索に限定し、無関係な結果を除外する
-      params = { q: "intitle:#{query}", key: ENV.fetch('GOOGLE_BOOKS_API_KEY'), maxResults: 40, langRestrict: 'ja' }
+      # intitle: でタイトル検索に限定し、無関係な結果を除外する。
+      # langRestrict=ja は Google Books API が特定の日本語クエリで断続的に 503 を返すため付与しない
+      # （例: intitle:成瀬は天下を取りにいく。langRestrict=ja なしでは安定して結果が返る）。
+      # 代わりに volumeInfo.language で日本語書籍のみをクライアント側で絞り込む。
+      params = { q: "intitle:#{query}", key: ENV.fetch('GOOGLE_BOOKS_API_KEY'), maxResults: 40 }
       response = books_connection.get('/books/v1/volumes', params)
 
       items = response.body['items'] || []
-      items.map { |item| normalize(item) }
+      items.select { |item| japanese_or_unspecified?(item) }
+           .map { |item| normalize(item) }
     end
 
     private
+
+    # language が 'ja' の書籍を返す。language が未設定の場合も許容する
+    # （Google Books では古い書籍などで language が欠損するケースがあり、切り落とすのは過剰）。
+    def japanese_or_unspecified?(item)
+      language = item.dig('volumeInfo', 'language')
+      language.nil? || language == 'ja'
+    end
 
     def books_connection
       @books_connection ||= connection(url: BASE_URL)

--- a/backend/app/services/work_search_service.rb
+++ b/backend/app/services/work_search_service.rb
@@ -8,25 +8,36 @@ class WorkSearchService # rubocop:disable Metrics/ClassLength
   # 実装変更時にインクリメントしてキャッシュを無効化する
   # v4: シリーズ親説明流用の境界文字判定を追加（normalize 空白保持 + ratio 廃止）
   # v5: Google Books thumbnail URL を https:// に正規化（Mixed Content 対策 #155）
-  CACHE_VERSION = 'v5'
+  # v6: Google Books の langRestrict=ja を廃止しコード側で言語フィルタ
+  #     （langRestrict=ja 起因の 503 で空キャッシュされた結果を無効化する）
+  CACHE_VERSION = 'v6'
   ENRICHMENT_BATCH_SIZE = 5
 
   def search(query, media_type: nil)
     cache_key = "work_search:#{CACHE_VERSION}:#{media_type || 'all'}:#{query}"
+    cached = Rails.cache.read(cache_key)
+    return cached unless cached.nil?
 
-    Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) do
-      adapters = select_adapters(media_type)
-      results = fetch_from_adapters_in_parallel(adapters, query, media_type)
-      results = results.select { |r| r.media_type == media_type } if media_type.present?
-
-      enrich_books_via_openbd(results)
-      enrich_missing_descriptions(results)
-      share_series_descriptions(results)
-      sort_by_quality_and_popularity(results)
-    end
+    sorted = fetch_and_process(query, media_type)
+    # 外部 API の一時障害（例: Google Books の 5xx）で全アダプタが空配列を返したとき、
+    # 空配列を 12 時間キャッシュすると同じ検索が長時間ヒットしない事故になる。
+    # ヒットが 1 件以上ある場合のみキャッシュし、空のときは次回再試行させる。
+    Rails.cache.write(cache_key, sorted, expires_in: CACHE_TTL) if sorted.any?
+    sorted
   end
 
   private
+
+  def fetch_and_process(query, media_type)
+    adapters = select_adapters(media_type)
+    results = fetch_from_adapters_in_parallel(adapters, query, media_type)
+    results = results.select { |r| r.media_type == media_type } if media_type.present?
+
+    enrich_books_via_openbd(results)
+    enrich_missing_descriptions(results)
+    share_series_descriptions(results)
+    sort_by_quality_and_popularity(results)
+  end
 
   # クラス定数ではなくメソッドで返す（Zeitwerkのオートロード順序問題を回避）
   # movieにAniListを含める（アニメ映画はTMDBで除外されるためAniList経由で取得）

--- a/backend/spec/services/external_apis/google_books_adapter_spec.rb
+++ b/backend/spec/services/external_apis/google_books_adapter_spec.rb
@@ -79,6 +79,38 @@ RSpec.describe ExternalApis::GoogleBooksAdapter, type: :service do
         .with(query: hash_including(q: 'intitle:三体'))
     end
 
+    # langRestrict=ja は特定の日本語クエリで Google Books API が断続的に 503 を返すため送らない。
+    # 代わりにレスポンスの volumeInfo.language で日本語書籍のみをクライアント側フィルタする。
+    describe '言語フィルタ（langRestrict=ja を使わずコード側で絞り込む）' do
+      def build_item(id:, title:, language: nil)
+        volume_info = { 'title' => title }
+        volume_info['language'] = language if language
+        { 'id' => id, 'volumeInfo' => volume_info }
+      end
+
+      it 'langRestrict クエリパラメータを送らない' do
+        adapter.search('成瀬は天下を取りにいく')
+        expect(WebMock).to(have_requested(:get, /www.googleapis.com/)
+          .with { |req| req.uri.query.to_s.exclude?('langRestrict') })
+      end
+
+      it 'volumeInfo.language が ja の結果は返す' do
+        stub_books_response([build_item(id: 'n1', title: '成瀬は天下を取りにいく', language: 'ja')])
+        expect(adapter.search('成瀬は天下を取りにいく').map(&:title))
+          .to include('成瀬は天下を取りにいく')
+      end
+
+      it 'volumeInfo.language が ja 以外の結果は除外する' do
+        stub_books_response([
+                              build_item(id: 'cn1', title: '奪取天下的少女', language: 'zh-CN'),
+                              build_item(id: 'n1', title: '成瀬は天下を取りにいく', language: 'ja')
+                            ])
+        titles = adapter.search('成瀬は天下を取りにいく').map(&:title)
+        expect(titles).to include('成瀬は天下を取りにいく')
+        expect(titles).not_to include('奪取天下的少女')
+      end
+    end
+
     describe 'ISBN抽出' do
       # テストごとに変わるのは industryIdentifiers のみなので、共通部分をヘルパー化
       def build_book_item(identifiers: nil)

--- a/backend/spec/services/work_search_service_spec.rb
+++ b/backend/spec/services/work_search_service_spec.rb
@@ -741,5 +741,22 @@ RSpec.describe WorkSearchService, type: :service do
       service.search('テスト', media_type: 'anime')
       expect(Rails.cache.exist?("work_search:#{WorkSearchService::CACHE_VERSION}:anime:テスト")).to be true
     end
+
+    # 外部 API が一時的に 5xx を返し全アダプタが空配列を返すと、空キャッシュが
+    # 12 時間残り同じ検索が常にヒットしない事故を防ぐ。
+    it '空の結果はキャッシュせず次回呼び出しで再試行する' do
+      allow(anilist_double).to receive(:safe_search).and_return([])
+      service.search('一時失敗クエリ', media_type: 'anime')
+      service.search('一時失敗クエリ', media_type: 'anime')
+      expect(anilist_double).to have_received(:safe_search).twice
+      cache_key = "work_search:#{WorkSearchService::CACHE_VERSION}:anime:一時失敗クエリ"
+      expect(Rails.cache.exist?(cache_key)).to be false
+    end
+
+    it '結果が1件以上あればキャッシュし2回目はアダプタを呼ばない' do
+      service.search('ヒットあり', media_type: 'anime')
+      service.search('ヒットあり', media_type: 'anime')
+      expect(anilist_double).to have_received(:safe_search).exactly(:once)
+    end
   end
 end


### PR DESCRIPTION
## Summary

- 外部 API（特に Google Books）が特定の日本語クエリで断続的に 503 を返すと、`WorkSearchService` が空配列を 12 時間キャッシュしてしまい「検索しても作品が見つからない」状態が続いていた問題を修正。ユーザー報告（「成瀬は天下を取りにいく」が検索結果に表示されない）を契機に発見。
- `GoogleBooksAdapter` から `langRestrict=ja` を外し、`volumeInfo.language` によるサーバ側フィルタに置き換え。
- `WorkSearchService` は結果が 1 件以上あるときのみキャッシュし、空結果は次回検索で再試行できるように変更。既存の空キャッシュを無効化するため `CACHE_VERSION` を v5 → v6 にバンプ。

## 根本原因

1. Google Books API が `intitle:成瀬は天下を取りにいく` 等の一部日本語クエリで断続的に HTTP 503 を返す（実測 5 回中 4 回で発生）
2. `BaseAdapter` の Faraday retry（max: 2）も含め 3 試行全てが 503 の場合、`raise_error` ミドルウェア未設定のため例外化されず `response.body['items']` が nil → `GoogleBooksAdapter#search` は空配列を返す
3. `WorkSearchService` はその空配列を `Rails.cache.fetch` で 12 時間キャッシュするため、ユーザーは以後ずっと 0 件表示になる

修正前は単発の 503 が 12 時間の「見つからない」に増幅されていた。

## 汎用性

特定クエリや書籍ジャンル専用の対処ではなく、以下の通り全クエリ・全ジャンルに効く：
- `langRestrict` 削除と言語コードフィルタは全書籍クエリ対象
- 空キャッシュ回避は AniList / TMDB / IGDB / Google Books すべてのアダプタに効く（`media_type` もクエリも見ずに判定している）

## Test plan

- [x] `bundle exec rspec spec/` 633 examples, 0 failures
- [x] `bundle exec rubocop app/services/ spec/services/` 0 offenses
- [x] ローカル Rails で実 API を叩き、`Attempt 1: 503 → 0件（キャッシュなし）→ Attempt 2: 再試行 → 10件（キャッシュあり）` の挙動を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)