### PR TITLE
fix: 検索ページとライブラリページの検索バーデザインを統一

### DIFF
--- a/frontend/src/components/ui/SearchInput/SearchInput.tsx
+++ b/frontend/src/components/ui/SearchInput/SearchInput.tsx
@@ -1,4 +1,3 @@
-import type { KeyboardEvent } from 'react'
 import styles from './SearchInput.module.css'
 
 type SearchInputProps = {
@@ -16,11 +15,6 @@ export function SearchInput({
   size = 'md',
   'aria-label': ariaLabel,
 }: SearchInputProps) {
-  // Enter はフォーム送信を防ぎ、デバウンスに任せる
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') e.preventDefault()
-  }
-
   const wrapperClass = [styles.wrapper, size === 'sm' ? styles.sizeSm : '']
     .filter(Boolean)
     .join(' ')
@@ -47,7 +41,6 @@ export function SearchInput({
         className={styles.input}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        onKeyDown={handleKeyDown}
         placeholder={placeholder}
         aria-label={ariaLabel}
         maxLength={200}

--- a/frontend/src/pages/SearchPage/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage/SearchPage.module.css
@@ -10,27 +10,7 @@
 }
 
 .searchForm {
-  display: flex;
-  gap: var(--spacing-sm);
   margin-top: var(--spacing-lg);
-}
-
-/* FormInputのラッパー: 検索フォーム内で横幅を確保し、ラベルは視覚的に隠す */
-.searchInputWrapper {
-  flex: 1;
-}
-
-/* FormInputのラベルをスクリーンリーダー専用にする（視覚的に非表示） */
-.searchInputWrapper label {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border: 0;
 }
 
 .filters {

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -103,7 +103,7 @@ describe('SearchPage', () => {
 
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, 'テスト')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(screen.getByText('テスト作品')).toBeInTheDocument()
@@ -121,7 +121,7 @@ describe('SearchPage', () => {
 
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, '存在しない')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(screen.getByText('作品が見つかりませんでした')).toBeInTheDocument()
@@ -158,7 +158,7 @@ describe('SearchPage', () => {
 
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, '進撃の巨人')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(screen.getByText('進撃の巨人')).toBeInTheDocument()
@@ -206,7 +206,7 @@ describe('SearchPage', () => {
 
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, 'テスト作品')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(screen.getByText('テストアニメ')).toBeInTheDocument()
@@ -253,7 +253,7 @@ describe('SearchPage', () => {
     // 検索実行
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, 'テスト')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     // 作品Aが表示されるのを待つ
     await waitFor(() => {
@@ -333,7 +333,7 @@ describe('SearchPage', () => {
 
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, 'テスト')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     // スケルトンカードが表示される
     await waitFor(() => {
@@ -370,7 +370,7 @@ describe('SearchPage', () => {
     renderSearchPage()
     const input = await screen.findByPlaceholderText('作品を検索...')
     await user.type(input, '人間失格')
-    await user.click(screen.getByRole('button', { name: /検索/ }))
+    await user.keyboard('{Enter}')
 
     // 1回目の結果が表示される
     await waitFor(() => {
@@ -388,7 +388,7 @@ describe('SearchPage', () => {
 
     await user.clear(input)
     await user.type(input, 'ワンピース')
-    await user.click(screen.getByRole('button', { name: /検索/ }))
+    await user.keyboard('{Enter}')
 
     // 2回目のレスポンスが返る前に、1回目の結果が画面から消えている
     await waitFor(() => {
@@ -435,13 +435,11 @@ describe('SearchPage', () => {
     renderSearchPage()
     const input = await screen.findByPlaceholderText('作品を検索...')
     await user.type(input, '古い検索')
-    await user.click(screen.getByRole('button', { name: /検索/ }))
+    await user.keyboard('{Enter}')
 
     // 2回目の検索を直後に投げる
-    // 1回目の検索が永久保留のため検索ボタンが disabled のままになる。
-    // userEvent.click は disabled 要素では発火しないので、フォーム送信を直接 dispatch して
-    // handleSearch を呼ぶ（実アプリでも検索中の再送信は disabled で防がれるが、
-    // ここではレース条件のロジックそのものを検証したい）。
+    // Enter キーでは handleSearch 内の isSearching チェックが走らないため、
+    // フォーム送信を直接 dispatch してレース条件のロジックを検証する。
     await user.clear(input)
     await user.type(input, '新しい検索')
     const form = input.closest('form')
@@ -515,7 +513,7 @@ describe('SearchPage', () => {
 
     const input = await screen.findByPlaceholderText('作品を検索...')
     await user.type(input, '進撃')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(captureEvent).toHaveBeenCalledWith(ANALYTICS_EVENTS.SEARCH_PERFORMED, {
@@ -535,7 +533,7 @@ describe('SearchPage', () => {
 
     const input = await screen.findByPlaceholderText('作品を検索...')
     await user.type(input, 'x')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       // エラーメッセージが表示されることを確認（APIが呼ばれたことの証明）
@@ -583,7 +581,7 @@ describe('SearchPage', () => {
 
     const input = await screen.findByPlaceholderText('作品を検索...')
     await user.type(input, '進撃')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(captureEvent).toHaveBeenCalledWith(
@@ -653,7 +651,7 @@ describe('SearchPage', () => {
     // 検索実行
     const searchInput = await screen.findByPlaceholderText('作品を検索...')
     await user.type(searchInput, 'テスト')
-    await user.click(screen.getByRole('button', { name: '検索' }))
+    await user.keyboard('{Enter}')
 
     await waitFor(() => {
       expect(screen.getByText('テストアニメ')).toBeInTheDocument()

--- a/frontend/src/pages/SearchPage/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.tsx
@@ -7,7 +7,7 @@ import { worksApi } from '../../lib/worksApi'
 import { recordsApi } from '../../lib/recordsApi'
 import { imagesApi } from '../../lib/imagesApi'
 import { ApiError } from '../../lib/api'
-import { FormInput } from '../../components/ui/FormInput/FormInput'
+import { SearchInput } from '../../components/ui/SearchInput/SearchInput'
 import { WorkCard } from '../../components/WorkCard/WorkCard'
 import { SearchSkeleton } from '../../components/SearchSkeleton/SearchSkeleton'
 import { SearchProgress } from '../../components/SearchProgress/SearchProgress'
@@ -242,19 +242,12 @@ export function SearchPage() {
         <SectionTitle>作品検索</SectionTitle>
 
         <form className={styles.searchForm} onSubmit={handleSearch}>
-          <div className={styles.searchInputWrapper}>
-            <FormInput
-              label="検索"
-              id="search"
-              type="text"
-              placeholder="作品を検索..."
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-            />
-          </div>
-          <Button variant="primary" type="submit" disabled={isSearching}>
-            {isSearching ? '検索中...' : '検索'}
-          </Button>
+          <SearchInput
+            value={query}
+            onChange={(value) => setQuery(value)}
+            placeholder="作品を検索..."
+            aria-label="作品を検索"
+          />
         </form>
 
         {/* PC: ピルボタン */}


### PR DESCRIPTION
## 概要

- 検索ページ（`/search`）が `FormInput` ＋「検索」ボタン形式
- ライブラリページ（`/library`）が `SearchInput`（虫眼鏡アイコン入り）

デザインが不統一だったため、両ページで `SearchInput` に統一した。

## 変更内容

- `SearchInput.tsx`: Enter キーの `preventDefault` を削除（フォーム送信と共存できるよう）
- `SearchPage.tsx`: `FormInput` ＋ `Button` を `SearchInput` に置き換え
- `SearchPage.module.css`: 不要になった `searchInputWrapper` スタイルを削除

## テスト確認

- [ ] `/search` で虫眼鏡アイコン付き検索バーが表示される
- [ ] Enter キーで検索が実行される
- [ ] `/library` の検索バーに変化がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)