### PR TITLE
docs: マージ戦略をSquash and mergeに変更

### DIFF
--- a/.claude/rules/git-rules.md
+++ b/.claude/rules/git-rules.md
@@ -15,10 +15,11 @@ refactor: 認証ロジックを整理
 
 ## マージ戦略
 
-- **全PRをMerge commitで統一する**
-- Squash and merge は使用しない
+- **全PRをSquash and mergeで統一する**（2026-07-17変更。旧: Merge commit統一。理由: dependabot PRの積み重ねでコミットグラフが読みにくくなったため）
+- Merge commit は使用しない
 - Rebase and merge は使用しない
 - mainへの直接プッシュは禁止。ドキュメントのみの変更でも必ずブランチを切ってPR経由でマージする
+- Squash and mergeへの切り替え以前にマージされた履歴（Merge commit）はそのまま残す。過去のグラフを整理する目的でのhistory書き換えは行わない
 
 ## PRルール
 


### PR DESCRIPTION
## 概要
- dependabot PRの積み重ねでMerge commit運用だとコミットグラフが読みにくくなったため、Squash and mergeに統一
- GitHubリポジトリ設定も合わせて変更済み（allow_merge_commit=false, allow_rebase_merge=false, allow_squash_merge=true）
- 過去の履歴（Merge commit）はそのまま維持し、書き換えは行わない

## 変更内容
- `.claude/rules/git-rules.md` のマージ戦略セクションを更新

## テスト計画
- [x] ドキュメントのみの変更のためテスト不要