### PR TITLE
feat: 検索結果カードのジャケットクリックで記録モーダルを開けるようにする

### DIFF
--- a/docs/superpowers/plans/2026-07-17-search-card-click-to-record.md
+++ b/docs/superpowers/plans/2026-07-17-search-card-click-to-record.md
@@ -1,0 +1,999 @@
+# 検索結果カードのジャケットクリック記録化 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 検索結果カード（`WorkCard`）の「記録する」ボタンを廃止し、カード全体のクリック（ジャケット＋ジャンル＋タイトル）で `RecordModal` を開けるようにする。記録済み作品はモーダルを開いた上でフォームを無効化する。あわせてグリッド列数・ホバー効果をライブラリ画面に揃える。
+
+**Architecture:** `WorkCard` を `<button>` を持つカードから `role="button"` を持つクリック可能なカード（div）に作り替える。記録済み判定は既存の `recordedIds`（`SearchPage` が保持）をそのまま流用し、新たに `RecordModal` にも `alreadyRecorded` propとして渡す。`RecordModal` は `alreadyRecorded=true` のとき内部の `StatusSelector` / `RatingSlider` を無効化し、確定ボタンを disabled にする。グリッド列数は `SearchPage.module.css` / `SearchSkeleton.module.css` の両方をライブラリ（`LibraryPage.module.css`）のブレークポイントに合わせる。
+
+**Tech Stack:** React 19 / TypeScript / Vite / Vitest + React Testing Library / CSS Modules
+
+## Global Constraints
+
+- `any` 型の使用禁止
+- スタイル値は `tokens.css` の CSS変数のみ使用（ハードコード禁止）
+- フォーム入力要素は共通コンポーネント（`StatusSelector` / `RatingSlider` 等）を使用、HTML の `<input>` 等を直接使わない
+- コメントは日本語で「なぜ」を書く
+- 1ファイル200行以内を目安
+- 未使用の import・変数・関数を残さない
+- 全機能にテスト必須（TDD: 失敗するテストを先に書いてから実装する）
+
+---
+
+## Task 1: StatusSelector に disabled prop を追加
+
+**Files:**
+- Modify: `frontend/src/components/ui/StatusSelector/StatusSelector.tsx`
+- Test: `frontend/src/components/ui/StatusSelector/StatusSelector.test.tsx`
+
+**Interfaces:**
+- Consumes: なし（既存コンポーネント単体）
+- Produces: `StatusSelectorProps.disabled?: boolean`（デフォルト `false`）。`true` のとき全ステータスボタンが `disabled` になる。Task 3 で `RecordModal` から利用する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/src/components/ui/StatusSelector/StatusSelector.test.tsx` の末尾（`describe` ブロック内、最後の `it` の後）に追加:
+
+```tsx
+  it('disabled指定時は全ボタンが無効化される', () => {
+    render(<StatusSelector value="watching" onChange={() => {}} mediaType="anime" disabled />)
+    expect(screen.getByRole('button', { name: '視聴中' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '視聴完了' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '視聴予定' })).toBeDisabled()
+  })
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/ui/StatusSelector/StatusSelector.test.tsx`
+Expected: FAIL（`disabled` prop が存在せず、ボタンが disabled にならないため `toBeDisabled()` が失敗する）
+
+- [ ] **Step 3: 最小実装**
+
+`frontend/src/components/ui/StatusSelector/StatusSelector.tsx` を以下に置き換える:
+
+```tsx
+import type { MediaType, RecordStatus } from '../../../lib/types'
+import { getStatusLabel } from '../../../lib/mediaTypeUtils'
+import styles from './StatusSelector.module.css'
+
+type StatusSelectorProps = {
+  value: RecordStatus
+  onChange: (status: RecordStatus) => void
+  mediaType?: MediaType
+  disabled?: boolean
+}
+
+const STATUS_VALUES: RecordStatus[] = [
+  'watching',
+  'completed',
+  'on_hold',
+  'dropped',
+  'plan_to_watch',
+]
+
+export function StatusSelector({
+  value,
+  onChange,
+  mediaType,
+  disabled = false,
+}: StatusSelectorProps) {
+  return (
+    <div className={styles.container}>
+      {STATUS_VALUES.map((status) => {
+        const label = getStatusLabel(status, mediaType)
+        return (
+          <button
+            key={status}
+            type="button"
+            className={`${styles.tab} ${value === status ? styles.active : ''}`}
+            onClick={() => onChange(status)}
+            aria-label={label}
+            disabled={disabled}
+          >
+            {label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ui/StatusSelector/StatusSelector.test.tsx`
+Expected: PASS（全テスト）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/components/ui/StatusSelector/StatusSelector.tsx frontend/src/components/ui/StatusSelector/StatusSelector.test.tsx
+git commit -m "feat: StatusSelectorにdisabled propを追加"
+```
+
+---
+
+## Task 2: RatingSlider に disabled prop を追加
+
+**Files:**
+- Modify: `frontend/src/components/ui/RatingSlider/RatingSlider.tsx`
+- Test: `frontend/src/components/ui/RatingSlider/RatingSlider.test.tsx`
+
+**Interfaces:**
+- Consumes: なし（既存コンポーネント単体）
+- Produces: `RatingSliderProps.disabled?: boolean`（デフォルト `false`）。`true` のとき `<input type="range">` が `disabled` になる。Task 3 で `RecordModal` から利用する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/src/components/ui/RatingSlider/RatingSlider.test.tsx` の末尾に追加:
+
+```tsx
+  it('disabled指定時はスライダーが無効化される', () => {
+    render(<RatingSlider value={5} onChange={() => {}} disabled />)
+    expect(screen.getByRole('slider')).toBeDisabled()
+  })
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/ui/RatingSlider/RatingSlider.test.tsx`
+Expected: FAIL（`disabled` prop が存在せず `toBeDisabled()` が失敗する）
+
+- [ ] **Step 3: 最小実装**
+
+`frontend/src/components/ui/RatingSlider/RatingSlider.tsx` の型定義と関数シグネチャ、`<input>` を以下のように変更する（他の行は変更しない）:
+
+```tsx
+type RatingSliderProps = {
+  value: number
+  onChange: (value: number) => void
+  mediaType?: MediaType
+  disabled?: boolean
+}
+
+export function RatingSlider({ value, onChange, mediaType, disabled = false }: RatingSliderProps) {
+```
+
+`<input type="range" ...>` に `disabled={disabled}` を追加:
+
+```tsx
+        <input
+          type="range"
+          min="0"
+          max="10"
+          step="1"
+          value={value}
+          onChange={handleChange}
+          disabled={disabled}
+          className={styles.slider}
+          style={
+            {
+              background: sliderBackground,
+              '--genre-color': genreColor,
+            } as React.CSSProperties
+          }
+        />
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd frontend && npx vitest run src/components/ui/RatingSlider/RatingSlider.test.tsx`
+Expected: PASS（全テスト）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/components/ui/RatingSlider/RatingSlider.tsx frontend/src/components/ui/RatingSlider/RatingSlider.test.tsx
+git commit -m "feat: RatingSliderにdisabled propを追加"
+```
+
+---
+
+## Task 3: RecordModal に alreadyRecorded prop を追加
+
+**Files:**
+- Modify: `frontend/src/components/RecordModal/RecordModal.tsx`
+- Modify: `frontend/src/components/RecordModal/RecordModal.module.css`
+- Test: `frontend/src/components/RecordModal/RecordModal.test.tsx`
+
+**Interfaces:**
+- Consumes: `StatusSelectorProps.disabled`（Task 1）、`RatingSliderProps.disabled`（Task 2）
+- Produces: `RecordModalProps.alreadyRecorded?: boolean`（デフォルト `false`）。Task 6 で `SearchPage` から `recordedIds.has(workKey)` を渡す。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/src/components/RecordModal/RecordModal.test.tsx` の末尾（最後の `it` ブロックの後、`describe` の閉じ括弧の前）に追加:
+
+```tsx
+
+  describe('alreadyRecorded=true のとき', () => {
+    const alreadyRecordedProps = {
+      isOpen: true,
+      title: '進撃の巨人',
+      mediaType: 'anime' as const,
+      mediaTypeLabel: 'アニメ',
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+      isLoading: false,
+      alreadyRecorded: true,
+    }
+
+    it('案内文が表示される', () => {
+      render(<RecordModal {...alreadyRecordedProps} />)
+      expect(screen.getByText('この作品はすでに記録済みです')).toBeInTheDocument()
+    })
+
+    it('確定ボタンが「記録済み」表示でdisabledになる', () => {
+      render(<RecordModal {...alreadyRecordedProps} />)
+      expect(screen.getByRole('button', { name: '記録済み' })).toBeDisabled()
+    })
+
+    it('ステータス・評価の入力が無効化される', () => {
+      render(<RecordModal {...alreadyRecordedProps} />)
+      expect(screen.getByRole('button', { name: '視聴中' })).toBeDisabled()
+      expect(screen.getByRole('slider')).toBeDisabled()
+    })
+
+    it('キャンセルボタンは操作可能', async () => {
+      const user = userEvent.setup()
+      const handleCancel = vi.fn()
+      render(<RecordModal {...alreadyRecordedProps} onCancel={handleCancel} />)
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+      expect(handleCancel).toHaveBeenCalled()
+    })
+  })
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/RecordModal/RecordModal.test.tsx`
+Expected: FAIL（`alreadyRecorded` prop が存在せず、案内文が表示されず、確定ボタンが「記録する」のまま disabled にならない）
+
+- [ ] **Step 3: 最小実装**
+
+`frontend/src/components/RecordModal/RecordModal.tsx` を以下に置き換える:
+
+```tsx
+import { useState } from 'react'
+import type { MediaType, RecordStatus } from '../../lib/types'
+import { StatusSelector } from '../ui/StatusSelector/StatusSelector'
+import { RatingSlider } from '../ui/RatingSlider/RatingSlider'
+import { Button } from '../ui/Button/Button'
+import styles from './RecordModal.module.css'
+
+type RecordModalProps = {
+  isOpen: boolean
+  title: string
+  mediaType: MediaType
+  mediaTypeLabel: string
+  onConfirm: (data: { status: RecordStatus; rating: number | null }) => void
+  onCancel: () => void
+  isLoading: boolean
+  alreadyRecorded?: boolean
+}
+
+export function RecordModal({
+  isOpen,
+  title,
+  mediaType,
+  mediaTypeLabel,
+  onConfirm,
+  onCancel,
+  isLoading,
+  alreadyRecorded = false,
+}: RecordModalProps) {
+  const [status, setStatus] = useState<RecordStatus>('watching')
+  const [rating, setRating] = useState<number | null>(null)
+
+  if (!isOpen) return null
+
+  const handleConfirm = () => {
+    onConfirm({ status, rating })
+  }
+
+  return (
+    <div className={styles.overlay} onClick={onCancel}>
+      <div className={styles.modal} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h3 className={styles.title}>{title}を記録</h3>
+          <p className={styles.meta}>{mediaTypeLabel}</p>
+        </div>
+
+        {alreadyRecorded && (
+          <p className={styles.alreadyRecordedNotice}>この作品はすでに記録済みです</p>
+        )}
+
+        <div className={styles.card}>
+          <label className={styles.label}>ステータス</label>
+          <StatusSelector
+            value={status}
+            onChange={setStatus}
+            mediaType={mediaType}
+            disabled={alreadyRecorded}
+          />
+        </div>
+
+        <div className={styles.card}>
+          <label className={styles.label}>評価（任意）</label>
+          <RatingSlider
+            value={rating ?? 0}
+            onChange={(v) => setRating(v === 0 ? null : v)}
+            disabled={alreadyRecorded}
+          />
+        </div>
+
+        <div className={styles.actions}>
+          <Button
+            variant="primary"
+            onClick={handleConfirm}
+            disabled={isLoading || alreadyRecorded}
+          >
+            {alreadyRecorded ? '記録済み' : isLoading ? '記録中...' : '記録する'}
+          </Button>
+          <Button variant="secondary" onClick={onCancel}>
+            キャンセル
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+```
+
+`frontend/src/components/RecordModal/RecordModal.module.css` の末尾に追加:
+
+```css
+
+.alreadyRecordedNotice {
+  font-family: var(--font-body);
+  font-size: var(--font-size-meta);
+  color: var(--color-text-muted);
+  text-align: center;
+  margin: 0 0 var(--spacing-md) 0;
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd frontend && npx vitest run src/components/RecordModal/RecordModal.test.tsx`
+Expected: PASS（既存テスト・新規テストとも全てPASS。既存の `defaultProps` は `alreadyRecorded` を渡していないためデフォルト値 `false` で従来通り動作する）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/components/RecordModal/RecordModal.tsx frontend/src/components/RecordModal/RecordModal.module.css frontend/src/components/RecordModal/RecordModal.test.tsx
+git commit -m "feat: RecordModalにalreadyRecorded propを追加"
+```
+
+---
+
+## Task 4: WorkCard のボタンを廃止しカード全体をクリック可能にする
+
+**Files:**
+- Modify: `frontend/src/components/WorkCard/WorkCard.tsx`
+- Modify: `frontend/src/components/WorkCard/WorkCard.module.css`
+- Test: `frontend/src/components/WorkCard/WorkCard.test.tsx`
+
+**Interfaces:**
+- Consumes: なし
+- Produces: `WorkCardProps`（`isLoading` を削除）。カード要素は `role="button"` `tabIndex={0}`。`aria-label` は未記録時 `` `${work.title}を記録する` ``、記録済み時 `` `${work.title}（記録済み）` ``。クリック・Enter/Spaceキーで `onRecord(work)` を呼ぶ（記録済みでも呼ぶ）。Task 6 で `SearchPage` から利用する。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/src/components/WorkCard/WorkCard.test.tsx` を以下に置き換える:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { WorkCard } from './WorkCard'
+import type { SearchResult } from '../../lib/types'
+
+const mockWork: SearchResult = {
+  title: 'テスト作品',
+  media_type: 'anime',
+  description: 'テストの説明文',
+  cover_image_url: 'https://example.com/cover.jpg',
+  total_episodes: 12,
+  external_api_id: '123',
+  external_api_source: 'anilist',
+  metadata: {},
+}
+
+describe('WorkCard', () => {
+  it('作品タイトルが表示される', () => {
+    render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
+    expect(screen.getByText('テスト作品')).toBeInTheDocument()
+  })
+
+  it('ジャンルラベルが表示される', () => {
+    render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
+    expect(screen.getByText('アニメ')).toBeInTheDocument()
+  })
+
+  it('「記録する」ボタンは表示されない（カード全体がクリック対象のため）', () => {
+    render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
+    expect(screen.queryByRole('button', { name: '記録する' })).not.toBeInTheDocument()
+  })
+
+  it('カードクリックでコールバックが呼ばれる', async () => {
+    const onRecord = vi.fn()
+    render(<WorkCard work={mockWork} onRecord={onRecord} />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'テスト作品を記録する' }))
+    expect(onRecord).toHaveBeenCalledWith(mockWork)
+  })
+
+  it('Enterキーでコールバックが呼ばれる', async () => {
+    const onRecord = vi.fn()
+    render(<WorkCard work={mockWork} onRecord={onRecord} />)
+    const user = userEvent.setup()
+    screen.getByRole('button', { name: 'テスト作品を記録する' }).focus()
+    await user.keyboard('{Enter}')
+    expect(onRecord).toHaveBeenCalledWith(mockWork)
+  })
+
+  it('記録済みの場合はカードクリックでもコールバックが呼ばれる', async () => {
+    const onRecord = vi.fn()
+    render(<WorkCard work={mockWork} onRecord={onRecord} isRecorded />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'テスト作品（記録済み）' }))
+    expect(onRecord).toHaveBeenCalledWith(mockWork)
+  })
+
+  it('記録済みの場合は「記録済み」と表示される', () => {
+    render(<WorkCard work={mockWork} onRecord={vi.fn()} isRecorded />)
+    expect(screen.getByText('記録済み')).toBeInTheDocument()
+  })
+
+  it('カバー画像が表示される', () => {
+    render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
+    const img = screen.getByRole('img')
+    expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
+  })
+
+  it('記録済みの場合は「記録済み」がaction領域に表示される', () => {
+    const { container } = render(<WorkCard work={mockWork} onRecord={vi.fn()} isRecorded />)
+    const action = container.querySelector('[class*="action"]')
+    expect(action?.textContent).toBe('記録済み')
+  })
+
+  it('説明文は表示しない（ADR-0044: 検索カードはジャケット・ジャンル・タイトルのみ）', () => {
+    render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
+    expect(screen.queryByText('テストの説明文')).not.toBeInTheDocument()
+  })
+
+  it('カバー画像がない場合はプレースホルダーを表示する', () => {
+    const { container } = render(
+      <WorkCard work={{ ...mockWork, cover_image_url: null }} onRecord={vi.fn()} />,
+    )
+    expect(screen.queryByRole('img')).not.toBeInTheDocument()
+    expect(container.querySelector('[class*="coverPlaceholder"]')).toBeInTheDocument()
+  })
+})
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/WorkCard/WorkCard.test.tsx`
+Expected: FAIL（`role="button" name="テスト作品を記録する"` が存在しない。現状は「記録する」という名前のボタンが存在するため「表示されない」テストも失敗する）
+
+- [ ] **Step 3: 最小実装**
+
+`frontend/src/components/WorkCard/WorkCard.tsx` を以下に置き換える:
+
+```tsx
+import type { KeyboardEvent } from 'react'
+import type { SearchResult, MediaType } from '../../lib/types'
+import styles from './WorkCard.module.css'
+
+type WorkCardProps = {
+  work: SearchResult
+  onRecord: (work: SearchResult) => void
+  isRecorded?: boolean
+}
+
+const MEDIA_TYPE_LABELS: Record<MediaType, string> = {
+  anime: 'アニメ',
+  movie: '映画',
+  drama: 'ドラマ',
+  book: '本',
+  manga: '漫画',
+  game: 'ゲーム',
+}
+
+// ジャケット主体の縦型カード（ADR-0044）。カード全体のクリックで記録モーダルを開く
+export function WorkCard({ work, onRecord, isRecorded = false }: WorkCardProps) {
+  const handleClick = () => {
+    onRecord(work)
+  }
+
+  // ボタンではなくdivをクリック対象にしているため、Enter/Spaceキー操作を自前で処理する
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onRecord(work)
+    }
+  }
+
+  return (
+    <div
+      className={styles.card}
+      role="button"
+      tabIndex={0}
+      aria-label={isRecorded ? `${work.title}（記録済み）` : `${work.title}を記録する`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
+      <div className={styles.coverWrapper}>
+        {work.cover_image_url ? (
+          <img
+            className={styles.cover}
+            src={work.cover_image_url}
+            alt={`${work.title}のカバー画像`}
+            loading="lazy"
+          />
+        ) : (
+          <div className={styles.coverPlaceholder} />
+        )}
+      </div>
+      <div className={styles.info}>
+        <span className={`${styles.genre} ${styles[work.media_type]}`}>
+          {MEDIA_TYPE_LABELS[work.media_type]}
+        </span>
+        <h3 className={styles.title}>{work.title}</h3>
+      </div>
+      <div className={styles.action}>
+        {isRecorded && <span className={styles.recorded}>記録済み</span>}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd frontend && npx vitest run src/components/WorkCard/WorkCard.test.tsx`
+Expected: PASS（全テスト）
+
+- [ ] **Step 5: ホバー効果をライブラリ（RecordCardItem）に揃える**
+
+`frontend/src/components/WorkCard/WorkCard.module.css` の `.card` と `.card:hover` を以下に置き換える:
+
+```css
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  /* グリッドセル全体を埋め、タイトル行数の差でカード高さがばらつかないようにする */
+  height: 100%;
+  background-color: var(--color-bg-white);
+  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition:
+    background-color var(--transition-fast),
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
+}
+
+.card:hover {
+  background-color: var(--color-bg);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+}
+```
+
+- [ ] **Step 6: テストが引き続き通ることを確認**
+
+Run: `cd frontend && npx vitest run src/components/WorkCard/WorkCard.test.tsx`
+Expected: PASS（CSSのみの変更のためテスト結果に影響なし）
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add frontend/src/components/WorkCard/WorkCard.tsx frontend/src/components/WorkCard/WorkCard.module.css frontend/src/components/WorkCard/WorkCard.test.tsx
+git commit -m "feat: WorkCardの記録ボタンを廃止しカード全体をクリック可能にする"
+```
+
+---
+
+## Task 5: SearchSkeleton の列数をライブラリに合わせる
+
+**Files:**
+- Modify: `frontend/src/components/SearchSkeleton/SearchSkeleton.tsx`
+- Modify: `frontend/src/components/SearchSkeleton/SearchSkeleton.module.css`
+- Test: `frontend/src/components/SearchSkeleton/SearchSkeleton.test.tsx`
+
+**Interfaces:**
+- Consumes: なし
+- Produces: なし（`SearchPage` からは props なしで呼び出される既存の関係を維持）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/src/components/SearchSkeleton/SearchSkeleton.test.tsx` の `toHaveLength(5)` を `toHaveLength(6)` に、テスト名も合わせて変更する:
+
+```tsx
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SearchSkeleton } from './SearchSkeleton'
+
+describe('SearchSkeleton', () => {
+  it('スケルトンカードがグリッド1行分（6枚）レンダリングされる', () => {
+    render(<SearchSkeleton />)
+    const cards = screen.getAllByRole('status')
+    expect(cards).toHaveLength(6)
+  })
+
+  it('各カードにaria-labelが設定されている', () => {
+    render(<SearchSkeleton />)
+    const cards = screen.getAllByRole('status')
+    cards.forEach((card) => {
+      expect(card).toHaveAttribute('aria-label', '読み込み中')
+    })
+  })
+})
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/components/SearchSkeleton/SearchSkeleton.test.tsx`
+Expected: FAIL（`SKELETON_COUNT` が5のままのため `cards` の長さが5になり、期待値6と一致しない）
+
+- [ ] **Step 3: 最小実装**
+
+`frontend/src/components/SearchSkeleton/SearchSkeleton.tsx` を以下に置き換える（記録ボタンを廃止したため `buttonPlaceholder` も削除する）:
+
+```tsx
+import styles from './SearchSkeleton.module.css'
+
+// グリッド1行分（PC6列）を埋める数
+const SKELETON_COUNT = 6
+
+// 各カードのシマー開始タイミングをずらすためのディレイ
+const ANIMATION_DELAYS = ['0s', '0.1s', '0.2s', '0.3s', '0.4s', '0.5s']
+
+// ジャケット主体の縦型カード（WorkCard）と同じ形のスケルトンをグリッド表示する
+export function SearchSkeleton() {
+  return (
+    <div className={styles.container}>
+      {Array.from({ length: SKELETON_COUNT }, (_, i) => (
+        <div key={i} className={styles.card} role="status" aria-label="読み込み中">
+          <div
+            className={styles.coverPlaceholder}
+            style={{ animationDelay: ANIMATION_DELAYS[i] }}
+          />
+          <div className={styles.info}>
+            <div
+              className={`${styles.line} ${styles.lineGenre}`}
+              style={{ animationDelay: ANIMATION_DELAYS[i] }}
+            />
+            <div
+              className={`${styles.line} ${styles.lineTitle}`}
+              style={{ animationDelay: ANIMATION_DELAYS[i] }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+```
+
+`frontend/src/components/SearchSkeleton/SearchSkeleton.module.css` を以下に置き換える（列数をライブラリ基準の6/4/3・ブレークポイントを1024px/768pxに変更し、`.buttonPlaceholder` を削除）:
+
+```css
+/* WorkCard の縦型カードと同じ形・同じグリッド列数のスケルトン（ライブラリ画面のグリッドに合わせる） */
+.container {
+  margin-top: var(--spacing-lg);
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--spacing-md);
+}
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+  padding: var(--spacing-sm);
+  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
+  border-radius: var(--radius-md);
+}
+
+.coverPlaceholder {
+  width: 100%;
+  aspect-ratio: 2 / 3;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    var(--color-border-light) 25%,
+    var(--color-skeleton-highlight) 50%,
+    var(--color-border-light) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
+}
+
+.line {
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    90deg,
+    var(--color-border-light) 25%,
+    var(--color-skeleton-highlight) 50%,
+    var(--color-border-light) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.5s infinite;
+}
+
+.lineGenre {
+  height: 10px;
+  width: 50%;
+}
+
+.lineTitle {
+  height: 14px;
+  width: 85%;
+}
+
+@keyframes shimmer {
+  0% {
+    background-position: -200% 0;
+  }
+  100% {
+    background-position: 200% 0;
+  }
+}
+
+@media (max-width: 1024px) {
+  .container {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .container {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd frontend && npx vitest run src/components/SearchSkeleton/SearchSkeleton.test.tsx`
+Expected: PASS（全テスト）
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add frontend/src/components/SearchSkeleton/SearchSkeleton.tsx frontend/src/components/SearchSkeleton/SearchSkeleton.module.css frontend/src/components/SearchSkeleton/SearchSkeleton.test.tsx
+git commit -m "feat: SearchSkeletonの列数をライブラリのグリッドに合わせる"
+```
+
+---
+
+## Task 6: SearchPage の統合（グリッドCSS・props配線・テスト更新）
+
+**Files:**
+- Modify: `frontend/src/pages/SearchPage/SearchPage.tsx`
+- Modify: `frontend/src/pages/SearchPage/SearchPage.module.css`
+- Test: `frontend/src/pages/SearchPage/SearchPage.test.tsx`
+
+**Interfaces:**
+- Consumes: `WorkCardProps`（Task 4、`isLoading` を渡さない）、`RecordModalProps.alreadyRecorded`（Task 3）
+- Produces: なし（ページコンポーネント）
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`frontend/src/pages/SearchPage/SearchPage.test.tsx` を以下の3箇所修正する。
+
+(a) 219行目付近の「連続で異なる作品を記録する際にステータス・評価がリセットされる」テスト内、ボタン取得部分を置き換える:
+
+- 263〜265行目を置き換え:
+```tsx
+    // 作品Aのカードをクリック → RecordModal が開く
+    await user.click(screen.getByRole('button', { name: '作品Aを記録する' }))
+```
+- 288〜290行目を置き換え:
+```tsx
+    // モーダル内の「記録する」をクリック
+    await user.click(screen.getByRole('button', { name: '記録する' }))
+```
+- 297〜299行目を置き換え:
+```tsx
+    // 作品Bのカードをクリック → RecordModal が開く
+    await user.click(screen.getByRole('button', { name: '作品Bを記録する' }))
+```
+- 315〜317行目を置き換え:
+```tsx
+    // 何も変更せずにそのまま「記録する」をクリック
+    await user.click(screen.getByRole('button', { name: '記録する' }))
+```
+
+(b) 340行目「検索中にスケルトンUIとプログレスが表示される」テスト内:
+```tsx
+    await waitFor(() => {
+      expect(screen.getAllByRole('status')).toHaveLength(6)
+    })
+```
+
+(c) 627行目「検索結果から記録を作成したら record_created を media_type 付きで発火する」テスト内、661〜662行目を置き換え:
+```tsx
+    // 記録モーダルを開く
+    await user.click(screen.getByRole('button', { name: 'テストアニメを記録する' }))
+```
+678〜679行目を置き換え:
+```tsx
+    // モーダル内の「記録する」をクリック
+    await user.click(screen.getByRole('button', { name: '記録する' }))
+```
+
+(d) ファイル末尾（最後の `it` ブロックの後、`describe` の閉じ括弧の前）に新規テストを追加:
+```tsx
+
+  it('記録済みの作品カードをクリックするとモーダルは開くが確定できない', async () => {
+    renderSearchPage()
+    const user = userEvent.setup()
+
+    // 検索API: アニメ作品 1 件を返す
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              title: 'テストアニメ',
+              media_type: 'anime',
+              description: 'アニメ説明',
+              cover_image_url: null,
+              total_episodes: 12,
+              external_api_id: '1',
+              external_api_source: 'anilist',
+              metadata: {},
+            },
+          ],
+        }),
+    })
+
+    const searchInput = await screen.findByPlaceholderText('作品を検索...')
+    await user.type(searchInput, 'テスト')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメ')).toBeInTheDocument()
+    })
+
+    // 1回目のクリック: 記録APIが409を返す（既に他経路で記録済み）
+    await user.click(screen.getByRole('button', { name: 'テストアニメを記録する' }))
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメを記録')).toBeInTheDocument()
+    })
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({ error: '既に記録済みです' }),
+    })
+    await user.click(screen.getByRole('button', { name: '記録する' }))
+
+    // モーダルが閉じ、カードが「記録済み」表示になる
+    await waitFor(() => {
+      expect(screen.queryByText('テストアニメを記録')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('記録済み')).toBeInTheDocument()
+
+    // 2回目のクリック: 記録済みカードをクリックしてもモーダルは開く
+    await user.click(screen.getByRole('button', { name: 'テストアニメ（記録済み）' }))
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメを記録')).toBeInTheDocument()
+    })
+    expect(screen.getByText('この作品はすでに記録済みです')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '記録済み' })).toBeDisabled()
+  })
+```
+
+- [ ] **Step 2: テストが失敗することを確認**
+
+Run: `cd frontend && npx vitest run src/pages/SearchPage/SearchPage.test.tsx`
+Expected: FAIL（`WorkCard` がまだ `role="button" name="...を記録する"` を持たず、`RecordModal` に `alreadyRecorded` が渡っていないため新規テストも失敗する）
+
+- [ ] **Step 3: 実装**
+
+`frontend/src/pages/SearchPage/SearchPage.tsx` の `WorkCard` 呼び出し（`isLoading` 行を削除）:
+
+```tsx
+                  <WorkCard
+                    work={work}
+                    onRecord={handleOpenModal}
+                    isRecorded={recordedIds.has(workKey)}
+                  />
+```
+
+`RecordModal` 呼び出しに `alreadyRecorded` を追加:
+
+```tsx
+      <RecordModal
+        key={
+          modalWork
+            ? `${modalWork.external_api_source ?? 'manual'}:${modalWork.external_api_id ?? manualWorkId}`
+            : 'closed'
+        }
+        isOpen={modalWork !== null}
+        title={modalWork?.title ?? ''}
+        mediaType={modalWork?.media_type ?? 'anime'}
+        mediaTypeLabel={modalWork ? getGenreLabel(modalWork.media_type) : ''}
+        onConfirm={handleConfirmRecord}
+        onCancel={() => {
+          setModalWork(null)
+          setManualWorkId(null)
+        }}
+        isLoading={loadingId !== null}
+        alreadyRecorded={
+          modalWork
+            ? recordedIds.has(`${modalWork.external_api_source}:${modalWork.external_api_id}`)
+            : false
+        }
+      />
+```
+
+`frontend/src/pages/SearchPage/SearchPage.module.css` の `.results` グリッドをライブラリ基準に変更:
+
+```css
+/* ジャケット主体の縦型カードを並べるグリッド（ADR-0044）。列数はライブラリ画面のグリッドに合わせる */
+.results {
+  margin-top: var(--spacing-lg);
+  display: grid;
+  grid-template-columns: repeat(6, 1fr);
+  gap: var(--spacing-md);
+}
+
+@media (max-width: 1024px) {
+  .results {
+    grid-template-columns: repeat(4, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .results {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+```
+
+- [ ] **Step 4: テストが通ることを確認**
+
+Run: `cd frontend && npx vitest run src/pages/SearchPage/SearchPage.test.tsx`
+Expected: PASS（全テスト）
+
+- [ ] **Step 5: フロントエンド全体のテスト・lintを実行**
+
+Run: `cd frontend && npm run test`
+Expected: PASS（全テストスイート）
+
+Run: `cd frontend && npm run lint`
+Expected: エラーなし
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add frontend/src/pages/SearchPage/SearchPage.tsx frontend/src/pages/SearchPage/SearchPage.module.css frontend/src/pages/SearchPage/SearchPage.test.tsx
+git commit -m "feat: SearchPageのグリッドをライブラリに揃えジャケットクリックで記録モーダルを開く"
+```
+
+---
+
+## 完了条件
+
+- [ ] 全タスクのテストがPASSしている
+- [ ] `cd frontend && npm run test` が全体でPASSする
+- [ ] `cd frontend && npm run lint` がエラーなしで通る
+- [ ] `docs/superpowers/plans/2026-07-17-search-card-click-to-record.md`（本ファイル）のチェックボックスが全て完了している

--- a/docs/superpowers/specs/2026-07-17-search-card-click-to-record-design.md
+++ b/docs/superpowers/specs/2026-07-17-search-card-click-to-record-design.md
@@ -1,0 +1,91 @@
+# 検索結果カードのジャケットクリック記録化 設計書
+
+作成日: 2026-07-17
+関連: [2026-07-16-search-ui-redesign-design.md](2026-07-16-search-ui-redesign-design.md)（ジャケット主体グリッドの導入元）
+関連ADR: [ADR-0044](../../adr/0044-検索結果から説明文を廃止し記録時補完に移行.md)（グリッドUI・記録フローの前提）
+
+## 概要
+
+検索結果カード（`WorkCard`）から「記録する」ボタンを廃止し、カード（ジャケット＋ジャンル＋タイトル）をクリックすることで `RecordModal` が開く形に変更する。あわせて、検索結果グリッドの列数・カードの見た目をライブラリ画面（`RecordCardItem`）に揃える。
+
+## 背景・経緯
+
+- ライブラリ画面のグリッドレイアウト（ジャケット主体・カード全体がクリック可能）のUXが好評で、検索結果にも同じ操作感を持たせたい
+- 現状の検索結果カードは「記録する」ボタンのみが操作対象で、ジャケット自体はクリックしても反応しない。ライブラリと挙動が異なり一貫性がない
+
+## 決定事項（2026-07-17 IKさん承認）
+
+| 論点 | 決定 |
+|------|------|
+| 記録ボタン | 削除する |
+| クリック可能範囲 | カード全体（ジャケット＋ジャンルバッジ＋タイトル） |
+| 記録済み作品のクリック | モーダルは開くが、フォーム・確定ボタンを無効化し「記録済み」であることを案内する |
+| グリッド列数 | ライブラリと同じ PC6列／タブレット(〜1024px)4列／モバイル(〜768px)3列に揃える |
+| カードの見た目 | ホバー時の浮き上がり効果（`translateY` + `box-shadow`）を `RecordCardItem` に揃える |
+
+## UI仕様
+
+### WorkCard（検索結果カード）
+
+- 「記録する」`<Button>` を削除
+- カード（`div`）に `role="button"` `tabIndex={0}` を付与し、クリック・Enter/Spaceキーで `onRecord(work)` を呼ぶ
+- 記録済み・未記録に関わらず常にクリック可能（記録済みでもモーダルを開く。モーダル側で送信を止める）
+- 「記録済み」バッジ表示は現状維持（状態表示のみで、クリック可否には影響しない）
+- `isLoading` prop は廃止する（モーダルのオーバーレイが背後のカードへのクリックを物理的に遮るため、カード側で二重送信を防ぐ意味がなくなるため）
+
+### RecordModal
+
+- 新規 prop `alreadyRecorded?: boolean`（デフォルト `false`）を追加
+- `true` の場合:
+  - `StatusSelector` / `RatingSlider` を無効化する
+  - 確定ボタンのラベルを「記録済み」にし、常に `disabled` にする
+  - ヘッダー直下に案内文「この作品はすでに記録済みです」を表示する
+  - キャンセルボタンのみ操作可能（閉じる）
+- `RecommendationsPage` からの呼び出しは変更しない（`alreadyRecorded` を渡さない限り従来通り）
+
+### グリッド・レイアウト
+
+- `SearchPage.module.css` の `.results` グリッド列数をライブラリ（`LibraryPage.module.css` の `.cardGrid`）に合わせて変更する
+  - PC: 6列 / タブレット(〜1024px): 4列 / モバイル(〜768px): 3列
+  - ブレークポイント基準も 1024px / 768px に統一する（現行は 768px / 480px）
+- `WorkCard.module.css` にホバー効果を追加
+  - `.card:hover` に `transform: translateY(-2px)` を追加（背景色変化は維持）
+  - `box-shadow` は `RecordCardItem` に揃えて `var(--shadow-md)` を使用
+
+## データフロー
+
+```
+WorkCard クリック（記録済み/未記録どちらも）
+  → SearchPage.handleOpenModal(work) → setModalWork(work)
+  → RecordModal isOpen=true, alreadyRecorded={recordedIds.has(workKey)}
+      - 未記録 → 通常どおり入力・確定可能（既存フロー）
+      - 記録済み → フォーム無効化・確定ボタン無効化・案内文表示
+      - キャンセルのみ操作可能
+```
+
+- `SearchPage.tsx` の `handleOpenModal` / `handleConfirmRecord` / `recordedIds` の管理ロジックは変更なし
+- `RecordModal` への渡し方のみ追加（`alreadyRecorded={recordedIds.has(workKey)}`）
+
+## 変更ファイル一覧（見込み）
+
+- `frontend/src/components/WorkCard/WorkCard.tsx` — ボタン削除・カードクリック化・キーボード対応・`isLoading` prop削除
+- `frontend/src/components/WorkCard/WorkCard.module.css` — ホバー効果追加
+- `frontend/src/components/WorkCard/WorkCard.test.tsx` — ボタンテストをカードクリック/キーボード操作テストに置換
+- `frontend/src/components/RecordModal/RecordModal.tsx` — `alreadyRecorded` prop追加
+- `frontend/src/components/RecordModal/RecordModal.module.css` — 案内文のスタイル追加（必要な場合）
+- `frontend/src/components/RecordModal/RecordModal.test.tsx` — `alreadyRecorded` 時の表示・disabled状態テスト追加
+- `frontend/src/pages/SearchPage/SearchPage.tsx` — `WorkCard` へのprops変更、`RecordModal` に `alreadyRecorded` を渡す
+- `frontend/src/pages/SearchPage/SearchPage.module.css` — グリッド列数・ブレークポイント変更
+- `frontend/src/pages/SearchPage/SearchPage.test.tsx`（存在すれば）— ジャケットクリックでモーダルが開くこと、記録済みクリック時の無効化を確認するテスト追加
+
+## テスト方針
+
+- `WorkCard`: カード（記録済み/未記録）クリックで `onRecord` が呼ばれること、Enter/Spaceキーでも同様に呼ばれること、「記録する」ボタンが存在しないこと
+- `RecordModal`: `alreadyRecorded=true` のとき確定ボタンが disabled で文言が「記録済み」になること、案内文が表示されること、入力コンポーネントが無効化されること
+- `SearchPage`: ジャケットクリックでモーダルが開くこと（既存の「記録するボタンクリックでモーダルが開く」テストの置き換え）、記録済み作品クリック時に `alreadyRecorded` が正しく渡ること
+
+## 既知のトレードオフ・影響範囲外
+
+- `RecommendationsPage` / `RecommendedWorkCard`（おすすめ画面の記録カード）は今回の変更対象外。将来的に統一するかは別途検討
+- ライブラリ画面の `RecordCardItem`（詳細ページへの遷移）は変更しない
+- カード全体をクリック領域にするため、将来的にカード内に別のインタラクティブ要素（例: お気に入りボタン等）を追加する場合はクリックイベントの伝播に注意が必要

--- a/frontend/src/components/RecordModal/RecordModal.module.css
+++ b/frontend/src/components/RecordModal/RecordModal.module.css
@@ -62,3 +62,11 @@
   gap: var(--spacing-sm);
   margin-top: var(--spacing-lg);
 }
+
+.alreadyRecordedNotice {
+  font-family: var(--font-body);
+  font-size: var(--font-size-meta);
+  color: var(--color-text-muted);
+  text-align: center;
+  margin: 0 0 var(--spacing-md) 0;
+}

--- a/frontend/src/components/RecordModal/RecordModal.test.tsx
+++ b/frontend/src/components/RecordModal/RecordModal.test.tsx
@@ -64,4 +64,41 @@ describe('RecordModal', () => {
     const { container } = render(<RecordModal {...defaultProps} isOpen={false} />)
     expect(container.innerHTML).toBe('')
   })
+
+  describe('alreadyRecorded=true のとき', () => {
+    const alreadyRecordedProps = {
+      isOpen: true,
+      title: '進撃の巨人',
+      mediaType: 'anime' as const,
+      mediaTypeLabel: 'アニメ',
+      onConfirm: vi.fn(),
+      onCancel: vi.fn(),
+      isLoading: false,
+      alreadyRecorded: true,
+    }
+
+    it('案内文が表示される', () => {
+      render(<RecordModal {...alreadyRecordedProps} />)
+      expect(screen.getByText('この作品はすでに記録済みです')).toBeInTheDocument()
+    })
+
+    it('確定ボタンが「記録済み」表示でdisabledになる', () => {
+      render(<RecordModal {...alreadyRecordedProps} />)
+      expect(screen.getByRole('button', { name: '記録済み' })).toBeDisabled()
+    })
+
+    it('ステータス・評価の入力が無効化される', () => {
+      render(<RecordModal {...alreadyRecordedProps} />)
+      expect(screen.getByRole('button', { name: '視聴中' })).toBeDisabled()
+      expect(screen.getByRole('slider')).toBeDisabled()
+    })
+
+    it('キャンセルボタンは操作可能', async () => {
+      const user = userEvent.setup()
+      const handleCancel = vi.fn()
+      render(<RecordModal {...alreadyRecordedProps} onCancel={handleCancel} />)
+      await user.click(screen.getByRole('button', { name: 'キャンセル' }))
+      expect(handleCancel).toHaveBeenCalled()
+    })
+  })
 })

--- a/frontend/src/components/RecordModal/RecordModal.tsx
+++ b/frontend/src/components/RecordModal/RecordModal.tsx
@@ -13,6 +13,7 @@ type RecordModalProps = {
   onConfirm: (data: { status: RecordStatus; rating: number | null }) => void
   onCancel: () => void
   isLoading: boolean
+  alreadyRecorded?: boolean
 }
 
 export function RecordModal({
@@ -23,6 +24,7 @@ export function RecordModal({
   onConfirm,
   onCancel,
   isLoading,
+  alreadyRecorded = false,
 }: RecordModalProps) {
   const [status, setStatus] = useState<RecordStatus>('watching')
   const [rating, setRating] = useState<number | null>(null)
@@ -41,19 +43,32 @@ export function RecordModal({
           <p className={styles.meta}>{mediaTypeLabel}</p>
         </div>
 
+        {alreadyRecorded && (
+          <p className={styles.alreadyRecordedNotice}>この作品はすでに記録済みです</p>
+        )}
+
         <div className={styles.card}>
           <label className={styles.label}>ステータス</label>
-          <StatusSelector value={status} onChange={setStatus} mediaType={mediaType} />
+          <StatusSelector
+            value={status}
+            onChange={setStatus}
+            mediaType={mediaType}
+            disabled={alreadyRecorded}
+          />
         </div>
 
         <div className={styles.card}>
           <label className={styles.label}>評価（任意）</label>
-          <RatingSlider value={rating ?? 0} onChange={(v) => setRating(v === 0 ? null : v)} />
+          <RatingSlider
+            value={rating ?? 0}
+            onChange={(v) => setRating(v === 0 ? null : v)}
+            disabled={alreadyRecorded}
+          />
         </div>
 
         <div className={styles.actions}>
-          <Button variant="primary" onClick={handleConfirm} disabled={isLoading}>
-            {isLoading ? '記録中...' : '記録する'}
+          <Button variant="primary" onClick={handleConfirm} disabled={isLoading || alreadyRecorded}>
+            {alreadyRecorded ? '記録済み' : isLoading ? '記録中...' : '記録する'}
           </Button>
           <Button variant="secondary" onClick={onCancel}>
             キャンセル

--- a/frontend/src/components/SearchSkeleton/SearchSkeleton.module.css
+++ b/frontend/src/components/SearchSkeleton/SearchSkeleton.module.css
@@ -1,18 +1,15 @@
-/* WorkCard の縦型カードと同じ形・同じグリッド列数のスケルトン（ライブラリ画面のグリッドに合わせる） */
+/* WorkCard の縦型カードと同じ形・同じグリッド間隔のスケルトン（白背景カードで囲わない見た目に合わせる） */
 .container {
   margin-top: var(--spacing-lg);
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
 }
 
 .card {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-  padding: var(--spacing-sm);
-  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
-  border-radius: var(--radius-md);
 }
 
 .coverPlaceholder {

--- a/frontend/src/components/SearchSkeleton/SearchSkeleton.module.css
+++ b/frontend/src/components/SearchSkeleton/SearchSkeleton.module.css
@@ -1,8 +1,8 @@
-/* WorkCard の縦型カードと同じ形・同じグリッド列数のスケルトン */
+/* WorkCard の縦型カードと同じ形・同じグリッド列数のスケルトン（ライブラリ画面のグリッドに合わせる） */
 .container {
   margin-top: var(--spacing-lg);
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: var(--spacing-md);
 }
 
@@ -58,20 +58,6 @@
   width: 85%;
 }
 
-.buttonPlaceholder {
-  width: 72px;
-  height: 32px;
-  border-radius: var(--radius-sm);
-  background: linear-gradient(
-    90deg,
-    var(--color-border-light) 25%,
-    var(--color-skeleton-highlight) 50%,
-    var(--color-border-light) 75%
-  );
-  background-size: 200% 100%;
-  animation: shimmer 1.5s infinite;
-}
-
 @keyframes shimmer {
   0% {
     background-position: -200% 0;
@@ -81,13 +67,13 @@
   }
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .container {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
   .container {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/frontend/src/components/SearchSkeleton/SearchSkeleton.test.tsx
+++ b/frontend/src/components/SearchSkeleton/SearchSkeleton.test.tsx
@@ -3,10 +3,10 @@ import { render, screen } from '@testing-library/react'
 import { SearchSkeleton } from './SearchSkeleton'
 
 describe('SearchSkeleton', () => {
-  it('スケルトンカードがグリッド1行分（5枚）レンダリングされる', () => {
+  it('スケルトンカードがグリッド1行分（6枚）レンダリングされる', () => {
     render(<SearchSkeleton />)
     const cards = screen.getAllByRole('status')
-    expect(cards).toHaveLength(5)
+    expect(cards).toHaveLength(6)
   })
 
   it('各カードにaria-labelが設定されている', () => {

--- a/frontend/src/components/SearchSkeleton/SearchSkeleton.tsx
+++ b/frontend/src/components/SearchSkeleton/SearchSkeleton.tsx
@@ -1,10 +1,10 @@
 import styles from './SearchSkeleton.module.css'
 
-// グリッド1行分（PC5列）を埋める数
-const SKELETON_COUNT = 5
+// グリッド1行分（PC6列）を埋める数
+const SKELETON_COUNT = 6
 
 // 各カードのシマー開始タイミングをずらすためのディレイ
-const ANIMATION_DELAYS = ['0s', '0.1s', '0.2s', '0.3s', '0.4s']
+const ANIMATION_DELAYS = ['0s', '0.1s', '0.2s', '0.3s', '0.4s', '0.5s']
 
 // ジャケット主体の縦型カード（WorkCard）と同じ形のスケルトンをグリッド表示する
 export function SearchSkeleton() {
@@ -26,10 +26,6 @@ export function SearchSkeleton() {
               style={{ animationDelay: ANIMATION_DELAYS[i] }}
             />
           </div>
-          <div
-            className={styles.buttonPlaceholder}
-            style={{ animationDelay: ANIMATION_DELAYS[i] }}
-          />
         </div>
       ))}
     </div>

--- a/frontend/src/components/WorkCard/WorkCard.module.css
+++ b/frontend/src/components/WorkCard/WorkCard.module.css
@@ -10,14 +10,17 @@
   background-color: var(--color-bg-white);
   border: var(--border-width-thin) var(--border-style) var(--color-border-light);
   border-radius: var(--radius-md);
+  cursor: pointer;
   transition:
     background-color var(--transition-fast),
-    box-shadow var(--transition-fast);
+    box-shadow var(--transition-fast),
+    transform var(--transition-fast);
 }
 
 .card:hover {
   background-color: var(--color-bg);
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
 }
 
 .coverWrapper {

--- a/frontend/src/components/WorkCard/WorkCard.module.css
+++ b/frontend/src/components/WorkCard/WorkCard.module.css
@@ -1,24 +1,19 @@
 /* WorkCard.module.css */
-/* ジャケット主体の縦型カード（ADR-0044）。グリッド内で使用する */
+/* ジャケット主体の縦型カード（ADR-0044）。ライブラリ画面（RecordCardItem）と同様、
+   白背景カードで囲わずジャケット・テキストを直接グリッドセルに乗せる */
 .card {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-  padding: var(--spacing-sm);
   /* グリッドセル全体を埋め、タイトル行数の差でカード高さがばらつかないようにする */
   height: 100%;
-  background-color: var(--color-bg-white);
-  border: var(--border-width-thin) var(--border-style) var(--color-border-light);
-  border-radius: var(--radius-md);
   cursor: pointer;
   transition:
-    background-color var(--transition-fast),
     box-shadow var(--transition-fast),
     transform var(--transition-fast);
 }
 
 .card:hover {
-  background-color: var(--color-bg);
   box-shadow: var(--shadow-md);
   transform: translateY(-2px);
 }
@@ -89,20 +84,6 @@
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
-  /* 1行タイトルでも2行分の高さを確保し、ボタン位置とカード高さを揃える */
+  /* 1行タイトルでも2行分の高さを確保し、カードの高さを行数に関わらず揃える */
   min-height: calc(var(--line-height-normal) * 2em);
-}
-
-.action {
-  display: flex;
-  align-items: center;
-  min-height: var(--spacing-xl);
-  /* カード下端に固定する（タイトル行数に関わらず揃える） */
-  margin-top: auto;
-}
-
-.recorded {
-  font-family: var(--font-body);
-  font-size: var(--font-size-meta);
-  color: var(--color-text-muted);
 }

--- a/frontend/src/components/WorkCard/WorkCard.test.tsx
+++ b/frontend/src/components/WorkCard/WorkCard.test.tsx
@@ -26,16 +26,33 @@ describe('WorkCard', () => {
     expect(screen.getByText('アニメ')).toBeInTheDocument()
   })
 
-  it('「記録する」ボタンが表示される', () => {
+  it('「記録する」ボタンは表示されない（カード全体がクリック対象のため）', () => {
     render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
-    expect(screen.getByRole('button', { name: '記録する' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: '記録する' })).not.toBeInTheDocument()
   })
 
-  it('「記録する」ボタン押下でコールバックが呼ばれる', async () => {
+  it('カードクリックでコールバックが呼ばれる', async () => {
     const onRecord = vi.fn()
     render(<WorkCard work={mockWork} onRecord={onRecord} />)
     const user = userEvent.setup()
-    await user.click(screen.getByRole('button', { name: '記録する' }))
+    await user.click(screen.getByRole('button', { name: 'テスト作品を記録する' }))
+    expect(onRecord).toHaveBeenCalledWith(mockWork)
+  })
+
+  it('Enterキーでコールバックが呼ばれる', async () => {
+    const onRecord = vi.fn()
+    render(<WorkCard work={mockWork} onRecord={onRecord} />)
+    const user = userEvent.setup()
+    screen.getByRole('button', { name: 'テスト作品を記録する' }).focus()
+    await user.keyboard('{Enter}')
+    expect(onRecord).toHaveBeenCalledWith(mockWork)
+  })
+
+  it('記録済みの場合はカードクリックでもコールバックが呼ばれる', async () => {
+    const onRecord = vi.fn()
+    render(<WorkCard work={mockWork} onRecord={onRecord} isRecorded />)
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'テスト作品（記録済み）' }))
     expect(onRecord).toHaveBeenCalledWith(mockWork)
   })
 
@@ -48,13 +65,6 @@ describe('WorkCard', () => {
     render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
     const img = screen.getByRole('img')
     expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
-  })
-
-  it('「記録する」ボタンがaction領域に配置されている', () => {
-    const { container } = render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
-    const action = container.querySelector('[class*="action"]')
-    expect(action).toBeInTheDocument()
-    expect(action?.querySelector('button')).toBeInTheDocument()
   })
 
   it('記録済みの場合は「記録済み」がaction領域に表示される', () => {

--- a/frontend/src/components/WorkCard/WorkCard.test.tsx
+++ b/frontend/src/components/WorkCard/WorkCard.test.tsx
@@ -56,21 +56,15 @@ describe('WorkCard', () => {
     expect(onRecord).toHaveBeenCalledWith(mockWork)
   })
 
-  it('記録済みの場合は「記録済み」と表示される', () => {
+  it('記録済みの場合も「記録済み」の文字は表示しない（一覧上は記録有無を表示しない）', () => {
     render(<WorkCard work={mockWork} onRecord={vi.fn()} isRecorded />)
-    expect(screen.getByText('記録済み')).toBeInTheDocument()
+    expect(screen.queryByText('記録済み')).not.toBeInTheDocument()
   })
 
   it('カバー画像が表示される', () => {
     render(<WorkCard work={mockWork} onRecord={vi.fn()} />)
     const img = screen.getByRole('img')
     expect(img).toHaveAttribute('src', 'https://example.com/cover.jpg')
-  })
-
-  it('記録済みの場合は「記録済み」がaction領域に表示される', () => {
-    const { container } = render(<WorkCard work={mockWork} onRecord={vi.fn()} isRecorded />)
-    const action = container.querySelector('[class*="action"]')
-    expect(action?.textContent).toBe('記録済み')
   })
 
   it('説明文は表示しない（ADR-0044: 検索カードはジャケット・ジャンル・タイトルのみ）', () => {

--- a/frontend/src/components/WorkCard/WorkCard.tsx
+++ b/frontend/src/components/WorkCard/WorkCard.tsx
@@ -58,9 +58,6 @@ export function WorkCard({ work, onRecord, isRecorded = false }: WorkCardProps) 
         </span>
         <h3 className={styles.title}>{work.title}</h3>
       </div>
-      <div className={styles.action}>
-        {isRecorded && <span className={styles.recorded}>記録済み</span>}
-      </div>
     </div>
   )
 }

--- a/frontend/src/components/WorkCard/WorkCard.tsx
+++ b/frontend/src/components/WorkCard/WorkCard.tsx
@@ -1,12 +1,11 @@
+import type { KeyboardEvent } from 'react'
 import type { SearchResult, MediaType } from '../../lib/types'
-import { Button } from '../ui/Button/Button'
 import styles from './WorkCard.module.css'
 
 type WorkCardProps = {
   work: SearchResult
   onRecord: (work: SearchResult) => void
   isRecorded?: boolean
-  isLoading?: boolean
 }
 
 const MEDIA_TYPE_LABELS: Record<MediaType, string> = {
@@ -18,16 +17,29 @@ const MEDIA_TYPE_LABELS: Record<MediaType, string> = {
   game: 'ゲーム',
 }
 
-// ジャケット主体の縦型カード（ADR-0044: 説明文は表示しない）
-export function WorkCard({ work, onRecord, isRecorded = false, isLoading = false }: WorkCardProps) {
-  const handleRecord = () => {
-    if (!isRecorded && !isLoading) {
+// ジャケット主体の縦型カード（ADR-0044）。カード全体のクリックで記録モーダルを開く
+export function WorkCard({ work, onRecord, isRecorded = false }: WorkCardProps) {
+  const handleClick = () => {
+    onRecord(work)
+  }
+
+  // ボタンではなくdivをクリック対象にしているため、Enter/Spaceキー操作を自前で処理する
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
       onRecord(work)
     }
   }
 
   return (
-    <div className={styles.card}>
+    <div
+      className={styles.card}
+      role="button"
+      tabIndex={0}
+      aria-label={isRecorded ? `${work.title}（記録済み）` : `${work.title}を記録する`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+    >
       <div className={styles.coverWrapper}>
         {work.cover_image_url ? (
           <img
@@ -47,13 +59,7 @@ export function WorkCard({ work, onRecord, isRecorded = false, isLoading = false
         <h3 className={styles.title}>{work.title}</h3>
       </div>
       <div className={styles.action}>
-        {isRecorded ? (
-          <span className={styles.recorded}>記録済み</span>
-        ) : (
-          <Button variant="primary" size="sm" onClick={handleRecord} disabled={isLoading}>
-            {isLoading ? '記録中...' : '記録する'}
-          </Button>
-        )}
+        {isRecorded && <span className={styles.recorded}>記録済み</span>}
       </div>
     </div>
   )

--- a/frontend/src/components/ui/RatingSlider/RatingSlider.test.tsx
+++ b/frontend/src/components/ui/RatingSlider/RatingSlider.test.tsx
@@ -55,4 +55,9 @@ describe('RatingSlider', () => {
       expect(screen.getAllByText(String(i)).length).toBeGreaterThanOrEqual(1)
     }
   })
+
+  it('disabled指定時はスライダーが無効化される', () => {
+    render(<RatingSlider value={5} onChange={() => {}} disabled />)
+    expect(screen.getByRole('slider')).toBeDisabled()
+  })
 })

--- a/frontend/src/components/ui/RatingSlider/RatingSlider.tsx
+++ b/frontend/src/components/ui/RatingSlider/RatingSlider.tsx
@@ -18,9 +18,10 @@ type RatingSliderProps = {
   value: number
   onChange: (value: number) => void
   mediaType?: MediaType
+  disabled?: boolean
 }
 
-export function RatingSlider({ value, onChange, mediaType }: RatingSliderProps) {
+export function RatingSlider({ value, onChange, mediaType, disabled = false }: RatingSliderProps) {
   const genreColor = mediaType ? GENRE_COLOR_VAR[mediaType] : 'var(--color-text)'
   const percentage = (value / 10) * 100
   const sliderBackground = `linear-gradient(to right, ${genreColor} ${String(percentage)}%, var(--color-border-light) ${String(percentage)}%)`
@@ -48,6 +49,7 @@ export function RatingSlider({ value, onChange, mediaType }: RatingSliderProps) 
           step="1"
           value={value}
           onChange={handleChange}
+          disabled={disabled}
           className={styles.slider}
           style={
             {

--- a/frontend/src/components/ui/StatusSelector/StatusSelector.test.tsx
+++ b/frontend/src/components/ui/StatusSelector/StatusSelector.test.tsx
@@ -46,4 +46,11 @@ describe('StatusSelector', () => {
     await user.click(screen.getByRole('button', { name: '視聴完了' }))
     expect(handleChange).toHaveBeenCalledWith('completed')
   })
+
+  it('disabled指定時は全ボタンが無効化される', () => {
+    render(<StatusSelector value="watching" onChange={() => {}} mediaType="anime" disabled />)
+    expect(screen.getByRole('button', { name: '視聴中' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '視聴完了' })).toBeDisabled()
+    expect(screen.getByRole('button', { name: '視聴予定' })).toBeDisabled()
+  })
 })

--- a/frontend/src/components/ui/StatusSelector/StatusSelector.tsx
+++ b/frontend/src/components/ui/StatusSelector/StatusSelector.tsx
@@ -6,6 +6,7 @@ type StatusSelectorProps = {
   value: RecordStatus
   onChange: (status: RecordStatus) => void
   mediaType?: MediaType
+  disabled?: boolean
 }
 
 const STATUS_VALUES: RecordStatus[] = [
@@ -16,7 +17,12 @@ const STATUS_VALUES: RecordStatus[] = [
   'plan_to_watch',
 ]
 
-export function StatusSelector({ value, onChange, mediaType }: StatusSelectorProps) {
+export function StatusSelector({
+  value,
+  onChange,
+  mediaType,
+  disabled = false,
+}: StatusSelectorProps) {
   return (
     <div className={styles.container}>
       {STATUS_VALUES.map((status) => {
@@ -28,6 +34,7 @@ export function StatusSelector({ value, onChange, mediaType }: StatusSelectorPro
             className={`${styles.tab} ${value === status ? styles.active : ''}`}
             onClick={() => onChange(status)}
             aria-label={label}
+            disabled={disabled}
           >
             {label}
           </button>

--- a/frontend/src/pages/RecommendationsPage/RecommendationsPage.module.css
+++ b/frontend/src/pages/RecommendationsPage/RecommendationsPage.module.css
@@ -1,6 +1,6 @@
-/* ページコンテナ */
+/* ページコンテナ（ライブラリ・検索のカードグリッドと同じ幅に揃える） */
 .container {
-  max-width: 800px;
+  max-width: 1100px;
   margin: var(--spacing-xl) auto;
   padding: 0 var(--spacing-xl);
 }

--- a/frontend/src/pages/SearchPage/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage/SearchPage.module.css
@@ -71,12 +71,13 @@
   margin-top: var(--spacing-sm);
 }
 
-/* ジャケット主体の縦型カードを並べるグリッド（ADR-0044）。列数はライブラリ画面のグリッドに合わせる */
+/* ジャケット主体の縦型カードを並べるグリッド（ADR-0044）。列数はライブラリ画面のグリッドに合わせる。
+   間隔はライブラリより意図的に詰めて、ジャケットの一覧性を高める */
 .results {
   margin-top: var(--spacing-lg);
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: var(--spacing-md);
+  gap: var(--spacing-sm);
 }
 
 @media (max-width: 1024px) {

--- a/frontend/src/pages/SearchPage/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage/SearchPage.module.css
@@ -4,8 +4,9 @@
   padding: var(--spacing-xl);
 }
 
+/* ライブラリ画面のカード表示時（.pageWide）と同じ幅に揃える */
 .container {
-  max-width: 800px;
+  max-width: 1100px;
   margin: 0 auto;
 }
 

--- a/frontend/src/pages/SearchPage/SearchPage.module.css
+++ b/frontend/src/pages/SearchPage/SearchPage.module.css
@@ -71,22 +71,21 @@
   margin-top: var(--spacing-sm);
 }
 
-/* ジャケット主体の縦型カードを並べるグリッド（ADR-0044） */
-/* 列数はADR-0026の3段階ブレークポイントに合わせる */
+/* ジャケット主体の縦型カードを並べるグリッド（ADR-0044）。列数はライブラリ画面のグリッドに合わせる */
 .results {
   margin-top: var(--spacing-lg);
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(6, 1fr);
   gap: var(--spacing-md);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 1024px) {
   .results {
     grid-template-columns: repeat(4, 1fr);
   }
 }
 
-@media (max-width: 480px) {
+@media (max-width: 768px) {
   .results {
     grid-template-columns: repeat(3, 1fr);
   }

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -728,11 +728,11 @@ describe('SearchPage', () => {
     })
     await user.click(screen.getByRole('button', { name: '記録する' }))
 
-    // モーダルが閉じ、カードが「記録済み」表示になる
+    // モーダルが閉じる（一覧上には「記録済み」の文字は表示しない）
     await waitFor(() => {
       expect(screen.queryByText('テストアニメを記録')).not.toBeInTheDocument()
     })
-    expect(screen.getByText('記録済み')).toBeInTheDocument()
+    expect(screen.queryByText('記録済み')).not.toBeInTheDocument()
 
     // 2回目のクリック: 記録済みカードをクリックしてもモーダルは開く
     await user.click(screen.getByRole('button', { name: 'テストアニメ（記録済み）' }))

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -742,4 +742,82 @@ describe('SearchPage', () => {
     expect(screen.getByText('この作品はすでに記録済みです')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: '記録済み' })).toBeDisabled()
   })
+
+  it('手動登録作品が409衝突しても、別の手動登録作品に記録済み状態が誤って伝播しない', async () => {
+    renderSearchPage()
+    const user = userEvent.setup()
+
+    // 1件目の手動作品を登録
+    await user.click(await screen.findByRole('button', { name: '+ 手動で登録する' }))
+    await user.type(await screen.findByLabelText('タイトル'), '手動作品A')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          work: {
+            id: 1,
+            title: '手動作品A',
+            media_type: 'anime',
+            description: null,
+            cover_image_url: null,
+            total_episodes: null,
+            external_api_id: null,
+            external_api_source: null,
+            metadata: {},
+            last_synced_at: null,
+            created_at: '2026-07-17T00:00:00Z',
+          },
+        }),
+    })
+    await user.click(screen.getByRole('button', { name: '登録する' }))
+
+    await waitFor(() => {
+      expect(screen.getByText('手動作品Aを記録')).toBeInTheDocument()
+    })
+
+    // 記録APIが409を返す（重複タイトル等の衝突を想定）
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({ error: '既に記録済みです' }),
+    })
+    await user.click(screen.getByRole('button', { name: '記録する' }))
+
+    await waitFor(() => {
+      expect(screen.queryByText('手動作品Aを記録')).not.toBeInTheDocument()
+    })
+
+    // 2件目の別の手動作品を登録
+    await user.click(await screen.findByRole('button', { name: '+ 手動で登録する' }))
+    await user.type(await screen.findByLabelText('タイトル'), '手動作品B')
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          work: {
+            id: 2,
+            title: '手動作品B',
+            media_type: 'anime',
+            description: null,
+            cover_image_url: null,
+            total_episodes: null,
+            external_api_id: null,
+            external_api_source: null,
+            metadata: {},
+            last_synced_at: null,
+            created_at: '2026-07-17T00:00:00Z',
+          },
+        }),
+    })
+    await user.click(screen.getByRole('button', { name: '登録する' }))
+
+    // 2件目は1件目とは別作品のため、記録済み状態を引き継がないはず
+    await waitFor(() => {
+      expect(screen.getByText('手動作品Bを記録')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('この作品はすでに記録済みです')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '記録する' })).toBeEnabled()
+  })
 })

--- a/frontend/src/pages/SearchPage/SearchPage.test.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.test.tsx
@@ -260,9 +260,8 @@ describe('SearchPage', () => {
       expect(screen.getByText('作品A')).toBeInTheDocument()
     })
 
-    // 作品Aの「記録する」をクリック → RecordModal が開く
-    const recordButtons = screen.getAllByRole('button', { name: '記録する' })
-    await user.click(recordButtons[0])
+    // 作品Aのカードをクリック → RecordModal が開く
+    await user.click(screen.getByRole('button', { name: '作品Aを記録する' }))
 
     // モーダルが開いたことを確認
     await waitFor(() => {
@@ -285,18 +284,16 @@ describe('SearchPage', () => {
         }),
     })
 
-    // 「記録する」をクリック（モーダル内の確定ボタン）
-    const confirmButtons = screen.getAllByRole('button', { name: '記録する' })
-    await user.click(confirmButtons[confirmButtons.length - 1])
+    // モーダル内の「記録する」をクリック
+    await user.click(screen.getByRole('button', { name: '記録する' }))
 
     // モーダルが閉じるのを待つ
     await waitFor(() => {
       expect(screen.queryByText('作品Aを記録')).not.toBeInTheDocument()
     })
 
-    // 作品Bの「記録する」をクリック → RecordModal が開く
-    const recordButtons2 = screen.getAllByRole('button', { name: '記録する' })
-    await user.click(recordButtons2[0])
+    // 作品Bのカードをクリック → RecordModal が開く
+    await user.click(screen.getByRole('button', { name: '作品Bを記録する' }))
 
     // モーダルが開いたことを確認
     await waitFor(() => {
@@ -313,8 +310,7 @@ describe('SearchPage', () => {
     })
 
     // 何も変更せずにそのまま「記録する」をクリック
-    const confirmButtons2 = screen.getAllByRole('button', { name: '記録する' })
-    await user.click(confirmButtons2[confirmButtons2.length - 1])
+    await user.click(screen.getByRole('button', { name: '記録する' }))
 
     // APIに送信されたデータを検証: 初期値（watching, ratingなし）で送信されているか
     // mockFetch の呼び出し履歴: [0]=認証, [1]=recorded_external_ids, [2]=検索, [3]=作品A記録, [4]=作品B記録
@@ -337,7 +333,7 @@ describe('SearchPage', () => {
 
     // スケルトンカードが表示される
     await waitFor(() => {
-      expect(screen.getAllByRole('status')).toHaveLength(5)
+      expect(screen.getAllByRole('status')).toHaveLength(6)
     })
     // プログレスメッセージが表示される
     expect(screen.getByText('作品を検索しています...')).toBeInTheDocument()
@@ -658,8 +654,7 @@ describe('SearchPage', () => {
     })
 
     // 記録モーダルを開く
-    const recordButtons = screen.getAllByRole('button', { name: '記録する' })
-    await user.click(recordButtons[0])
+    await user.click(screen.getByRole('button', { name: 'テストアニメを記録する' }))
 
     await waitFor(() => {
       expect(screen.getByText('テストアニメを記録')).toBeInTheDocument()
@@ -675,8 +670,7 @@ describe('SearchPage', () => {
     })
 
     // モーダル内の「記録する」をクリック
-    const confirmButtons = screen.getAllByRole('button', { name: '記録する' })
-    await user.click(confirmButtons[confirmButtons.length - 1])
+    await user.click(screen.getByRole('button', { name: '記録する' }))
 
     await waitFor(() => {
       expect(captureEvent).toHaveBeenCalledWith(ANALYTICS_EVENTS.RECORD_CREATED, {
@@ -687,5 +681,65 @@ describe('SearchPage', () => {
     await waitFor(() => {
       expect(updateMediaTypesCount).toHaveBeenCalledTimes(1)
     })
+  })
+
+  it('記録済みの作品カードをクリックするとモーダルは開くが確定できない', async () => {
+    renderSearchPage()
+    const user = userEvent.setup()
+
+    // 検索API: アニメ作品 1 件を返す
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          results: [
+            {
+              title: 'テストアニメ',
+              media_type: 'anime',
+              description: 'アニメ説明',
+              cover_image_url: null,
+              total_episodes: 12,
+              external_api_id: '1',
+              external_api_source: 'anilist',
+              metadata: {},
+            },
+          ],
+        }),
+    })
+
+    const searchInput = await screen.findByPlaceholderText('作品を検索...')
+    await user.type(searchInput, 'テスト')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメ')).toBeInTheDocument()
+    })
+
+    // 1回目のクリック: 記録APIが409を返す（既に他経路で記録済み）
+    await user.click(screen.getByRole('button', { name: 'テストアニメを記録する' }))
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメを記録')).toBeInTheDocument()
+    })
+
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 409,
+      json: () => Promise.resolve({ error: '既に記録済みです' }),
+    })
+    await user.click(screen.getByRole('button', { name: '記録する' }))
+
+    // モーダルが閉じ、カードが「記録済み」表示になる
+    await waitFor(() => {
+      expect(screen.queryByText('テストアニメを記録')).not.toBeInTheDocument()
+    })
+    expect(screen.getByText('記録済み')).toBeInTheDocument()
+
+    // 2回目のクリック: 記録済みカードをクリックしてもモーダルは開く
+    await user.click(screen.getByRole('button', { name: 'テストアニメ（記録済み）' }))
+    await waitFor(() => {
+      expect(screen.getByText('テストアニメを記録')).toBeInTheDocument()
+    })
+    expect(screen.getByText('この作品はすでに記録済みです')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: '記録済み' })).toBeDisabled()
   })
 })

--- a/frontend/src/pages/SearchPage/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.tsx
@@ -277,7 +277,6 @@ export function SearchPage() {
                     work={work}
                     onRecord={handleOpenModal}
                     isRecorded={recordedIds.has(workKey)}
-                    isLoading={loadingId === workKey}
                   />
                 </motion.div>
               )
@@ -312,6 +311,11 @@ export function SearchPage() {
           setManualWorkId(null)
         }}
         isLoading={loadingId !== null}
+        alreadyRecorded={
+          modalWork
+            ? recordedIds.has(`${modalWork.external_api_source}:${modalWork.external_api_id}`)
+            : false
+        }
       />
     </div>
   )

--- a/frontend/src/pages/SearchPage/SearchPage.tsx
+++ b/frontend/src/pages/SearchPage/SearchPage.tsx
@@ -42,6 +42,15 @@ function shouldShowEnglishHint(
   return gameCount <= 3
 }
 
+// 記録済み判定・記録APIで使う作品キー。手動登録作品は external_api_source/id が
+// null になるため、work.id ベースの別名前空間キーで衝突を避ける
+function workKeyOf(work: SearchResult, manualWorkId: number | null): string {
+  if (work.external_api_source && work.external_api_id) {
+    return `${work.external_api_source}:${work.external_api_id}`
+  }
+  return `manual:${manualWorkId ?? 'unknown'}`
+}
+
 export function SearchPage() {
   const [query, setQuery] = useState('')
   const [genre, setGenre] = useState<GenreFilter>('all')
@@ -137,7 +146,7 @@ export function SearchPage() {
         setManualWorkId(null)
       } else {
         // 検索結果作品: 既存のフロー
-        const workKey = `${modalWork.external_api_source}:${modalWork.external_api_id}`
+        const workKey = workKeyOf(modalWork, manualWorkId)
         setLoadingId(workKey)
         await recordsApi.createFromSearchResult(modalWork, data)
         captureEvent(ANALYTICS_EVENTS.RECORD_CREATED, {
@@ -152,7 +161,7 @@ export function SearchPage() {
         setError(err.message)
         // 409 Conflict = 既に記録済み → UIを「記録済み」に更新
         if (err.status === 409 && modalWork) {
-          const workKey = `${modalWork.external_api_source}:${modalWork.external_api_id}`
+          const workKey = workKeyOf(modalWork, manualWorkId)
           setRecordedIds((prev) => new Set(prev).add(workKey))
           setModalWork(null)
         }
@@ -270,7 +279,7 @@ export function SearchPage() {
             animate="visible"
           >
             {results.map((work) => {
-              const workKey = `${work.external_api_source}:${work.external_api_id}`
+              const workKey = workKeyOf(work, manualWorkId)
               return (
                 <motion.div key={workKey} variants={m.fadeInUp}>
                   <WorkCard
@@ -311,11 +320,7 @@ export function SearchPage() {
           setManualWorkId(null)
         }}
         isLoading={loadingId !== null}
-        alreadyRecorded={
-          modalWork
-            ? recordedIds.has(`${modalWork.external_api_source}:${modalWork.external_api_id}`)
-            : false
-        }
+        alreadyRecorded={modalWork ? recordedIds.has(workKeyOf(modalWork, manualWorkId)) : false}
       />
     </div>
   )


### PR DESCRIPTION
## 概要

- 検索結果カード（`WorkCard`）から「記録する」ボタンを廃止し、カード全体（ジャケット＋ジャンル＋タイトル）のクリックで `RecordModal` を開く形に変更
- 記録済み作品のクリックでもモーダルは開くが、フォーム・確定ボタンを無効化し「記録済み」であることを案内する
- 検索結果・おすすめページのグリッド/コンテナ幅をライブラリ画面に統一（列数6/4/3、コンテナ幅1100px、白背景カードで囲まない見た目）

## 実装の経緯

Issue #213 → 設計書 [`docs/superpowers/specs/2026-07-17-search-card-click-to-record-design.md`](../blob/feat/search-card-click-to-record/docs/superpowers/specs/2026-07-17-search-card-click-to-record-design.md) → 実装プラン [`docs/superpowers/plans/2026-07-17-search-card-click-to-record.md`](../blob/feat/search-card-click-to-record/docs/superpowers/plans/2026-07-17-search-card-click-to-record.md) の順でTDD運用し、6タスクをsubagent-driven-developmentで実装・タスクごとにレビュー、最後に全体レビュー（Ready to merge: Yes）を実施した。

その後、実機確認でのIKさんのフィードバック（スクリーンショット比較）に基づき以下を追加修正：
- WorkCardの白背景カード表示を撤去し、ライブラリと同じ「ジャケット直置き」の見た目に統一
- グリッド間隔をライブラリより意図的に詰める（gap: spacing-md→spacing-sm）
- 検索結果一覧の「記録済み」ラベル表示を撤去（内部状態・aria-label・モーダル無効化ロジックは維持）
- 検索・おすすめページのコンテナ幅をライブラリのカード表示幅（1100px）に統一

## 変更ファイル

- `frontend/src/components/WorkCard/` — カードクリック化、ボタン廃止、白背景カード撤去
- `frontend/src/components/RecordModal/` — `alreadyRecorded` prop追加
- `frontend/src/components/ui/StatusSelector/`, `frontend/src/components/ui/RatingSlider/` — `disabled` prop追加
- `frontend/src/components/SearchSkeleton/` — 列数・間隔をグリッドに追従
- `frontend/src/pages/SearchPage/` — グリッド・コンテナ幅・props配線
- `frontend/src/pages/RecommendationsPage/` — コンテナ幅統一

Closes #213

## Test plan

- [x] フロントエンド全テスト（`npm run test`）587件PASS
- [x] `npm run lint` クリーン
- [x] `tsc --noEmit` クリーン
- [x] IKさんによるブラウザでの実機確認（複数回のフィードバックを反映済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)